### PR TITLE
Function that convert movies to arrays (using opencv, on python2).

### DIFF
--- a/python/effectivecurrent2brightness.py
+++ b/python/effectivecurrent2brightness.py
@@ -157,7 +157,7 @@ def pulse2percept(temporal_model, ecs, retina, stimuli,
                 idx_list.append([yy, xx])
                 # the current contributed by each electrode for that spatial location
 
-    stim_data = np.array([s.data for s in stimuli]) # pulse train for each electrode
+    stim_data = np.array([s.data for s in stimuli])  # pulse train for each electrode
     sr_list = utils.parfor(calc_pixel, ecs_list, n_jobs=n_jobs,
                            func_args=[stim_data, temporal_model,
                                       rs,  stimuli[0].tsample, dojit])

--- a/python/electrode2currentmap.py
+++ b/python/electrode2currentmap.py
@@ -318,10 +318,10 @@ class Retina(object):
         """
         ecs = np.zeros(current_spread.shape)
         for id in range(0, len(current_spread.flat)):
-           ecs.flat[id]  = np.dot(current_spread.flat[self.axon_id[id]],
+            ecs.flat[id] = np.dot(current_spread.flat[self.axon_id[id]],
                                   self.axon_weight[id])
-        
-        ecs=ecs /ecs.max()
+
+        ecs = ecs / ecs.max()
 
         return ecs
 
@@ -350,12 +350,14 @@ class Retina(object):
         ecs = np.zeros((self.gridx.shape[0], self.gridx.shape[1],
                        len(electrode_array.electrodes)))
 
-        cs = ecs
+        cs =  np.zeros((self.gridx.shape[0], self.gridx.shape[1],
+                       len(electrode_array.electrodes)))
 
         for i, e in enumerate(electrode_array.electrodes):
             cs[..., i] = e.current_spread(self.gridx, self.gridy,
                                           alpha=alpha, n=n)
             ecs[..., i] = self.cm2ecm(cs[..., i])
+
         return ecs, cs
 
 

--- a/python/test_effectivecurrent2brightness.py
+++ b/python/test_effectivecurrent2brightness.py
@@ -23,10 +23,12 @@ def test_brightness_movie():
     electrode_array = e2cm.ElectrodeArray([1, 1], [0, 1], [0, 1])
     ecs, cs = retina.electrode_ecs(electrode_array)
     temporal_model = ec2b.TemporalModel()
+    fps = 30.
+    rs = int(1 / (fps * s1.tsample))
 
     # Smoke testing, feed the same stimulus through both electrodes:
     brightness_movie = ec2b.pulse2percept(temporal_model, ecs, retina,
-                                          [s1, s1])
+                                          [s1, s1], rs)
 
     fps = 30.0
     amplitude_transform = 'linear'
@@ -50,13 +52,12 @@ def test_brightness_movie():
                                  tsample=tsample,
                                  pulsetype=pulsetype,
                                  stimtype=stimtype)
-    fps = 30.
-    subsample_factor = 1 / (fps * m2pt.tsample)
+
+    rs = int(1 / (fps * m2pt.tsample))
     # Smoke testing, feed the same stimulus through both electrodes:
     brightness_movie = ec2b.pulse2percept(temporal_model, ecs, retina,
-                                          [m2pt, m2pt],
-                                          fps=fps)
+                                          [m2pt, m2pt], rs)
 
     npt.assert_almost_equal(brightness_movie.tsample,
-                            m2pt.tsample * subsample_factor,
+                            m2pt.tsample * rs,
                             decimal=4)

--- a/python/utils.py
+++ b/python/utils.py
@@ -146,3 +146,25 @@ def parfor(func, in_list, out_shape=None, n_jobs=-1, func_args=[],
         return np.array(results).reshape(out_shape)
     else:
         return results
+
+
+def mov2npy(movie_file, out_file):
+
+    # Don't import cv at module level. Instead we'll use this on python 2 sometimes...
+    try:
+        import cv
+    except ImportError:
+        e_s = "You do not have opencv installed. "
+        e_s += "You probably want to run this in Python 2"
+        raise ImportError(e_s)
+
+    capture = cv.CaptureFromFile(movie_file)
+    frames = []
+    img = cv.QueryFrame(capture)
+    while img is not None:
+        tmp = cv.CreateImage(cv.GetSize(img), 8, 3)
+        cv.CvtColor(img, tmp, cv.CV_BGR2RGB)
+        frames.append(np.asarray(cv.GetMat(tmp)))
+        img = cv.QueryFrame(capture)
+    frames = np.fliplr(np.rot90(np.mean(frames, -1).T, -1))
+    np.save(out_file, frames)


### PR DESCRIPTION
And also a few fixes to things that were breaking the tests. In particular, allocating `cs=ecs` in `electrode_ecs` causes a subtle bug where the two outputs end up being identical. This is a python thing where when two variable names point to the same variable, they both have the same value. So need to preallocate zeros separately to each one!