### PR TITLE
REVIEW mb/fixElectrodeArray

### DIFF
--- a/pulse2percept/effectivecurrent2brightness.py
+++ b/pulse2percept/effectivecurrent2brightness.py
@@ -280,7 +280,8 @@ def pulse2percept(stim, implant, tm=None, retina=None,
         Scaling factor applied to charge accumulation (used to be called
         epsilon). Default: 42.1.
     tol : float
-        Ignore pixels whose effective current is smaller than tol.
+        Ignore pixels whose effective current is smaller than a fraction `tol`
+        of the max value.
         Default: 0.05.
     use_ecs : bool
         Flag whether to use effective current spread (True) or regular
@@ -364,11 +365,15 @@ def pulse2percept(stim, implant, tm=None, retina=None,
     idx_list = []
     for xx in range(retina.gridx.shape[1]):
         for yy in range(retina.gridx.shape[0]):
-            if np.all(ecs[yy, xx] < tol):
+            if np.all(ecs[yy, xx] < tol * ecs.max()):
                 pass
             else:
                 ecs_list.append(ecs[yy, xx])
                 idx_list.append([yy, xx])
+
+    if verbose:
+        print("tol=%.3f, %d/%d pixels selected" % (tol, len(ecs_list),
+                                                   ecs.size))
 
     # Apply charge accumulation
     for i, p in enumerate(pt_list):

--- a/pulse2percept/electrode2currentmap.py
+++ b/pulse2percept/electrode2currentmap.py
@@ -159,13 +159,13 @@ class Electrode(object):
         fovdist = np.sqrt(self.x_center ** 2 + self.y_center ** 2)
         if fovdist <= 600:
             # Layer thicknesses given for 0-600 um distance (from fovea)
-            th_nfl = 4  # nerve fiber layer
-            th_gc = 56  # ganglion cell bodies + inner nuclear layer
-            th_bp = 23  # bipolar bodies + inner nuclear layer
+            th_nfl = 4.0  # nerve fiber layer
+            th_gc = 56.0  # ganglion cell bodies + inner nuclear layer
+            th_bp = 23.0  # bipolar bodies + inner nuclear layer
         elif fovdist <= 1550:
             # Layer thicknesses given for 600-1550 um distance (from fovea)
-            th_nfl = 34
-            th_gc = 87
+            th_nfl = 34.0
+            th_gc = 87.0
             th_bp = 37.5
         else:
             # Layer thicknesses given for 1550-3000 um distance (from fovea)

--- a/pulse2percept/electrode2currentmap.py
+++ b/pulse2percept/electrode2currentmap.py
@@ -331,7 +331,8 @@ class ElectrodeArray(object):
 
 class ArgusI(ElectrodeArray):
 
-    def __init__(self, x_center=0, y_center=0, h=0, rot=0 * np.pi / 180):
+    def __init__(self, x_center=0, y_center=0, h=0, rot=0 * np.pi / 180,
+                 use_legacy_names=False):
         """Create an ArgusI array on the retina
 
         This function creates an ArgusI array and places it on the retina
@@ -348,6 +349,7 @@ class ArgusI(ElectrodeArray):
         -->x    A4 B4 C4 D4                     520 260 520 260
 
         Electrode order is: A1, B1, C1, D1, A2, B2, ..., D4.
+        If `use_legacy_names` is True, electrode order is: L6, L2, M8, M4, ...
         An electrode can be addressed by index (integer) or name.
 
         Parameters
@@ -379,9 +381,17 @@ class ArgusI(ElectrodeArray):
         r_arr = np.concatenate((r_arr, r_arr[::-1], r_arr, r_arr[::-1]),
                                axis=0)
 
-        # Standard Argus I names: A1, B1, C1, D1, A1, B2, ..., D4
-        # Shortcut: Use `chr` to go from int to char
-        names = [chr(i) + str(j) for j in range(1, 5) for i in range(65, 69)]
+        if use_legacy_names:
+            # Legacy Argus I names
+            names = ['L6', 'L2', 'M8', 'M4',
+                     'L5', 'L1', 'M7', 'M3',
+                     'L8', 'L4', 'M6', 'M2',
+                     'L7', 'L3', 'M5', 'M1']
+        else:
+            # Standard Argus I names: A1, B1, C1, D1, A1, B2, ..., D4
+            # Shortcut: Use `chr` to go from int to char
+            names = [chr(i) + str(j) for j in range(1, 5)
+                     for i in range(65, 69)]
 
         if isinstance(h, list):
             h_arr = np.array(h).flatten()

--- a/pulse2percept/electrode2currentmap.py
+++ b/pulse2percept/electrode2currentmap.py
@@ -10,7 +10,7 @@ from scipy import interpolate
 from scipy.misc import factorial
 
 from pulse2percept import oyster
-from pulse2percept.utils import TimeSeries, randomly
+from pulse2percept.utils import TimeSeries, traverse_randomly
 
 
 def micron2deg(micron):
@@ -321,7 +321,7 @@ class ElectrodeArray(object):
         # Is `name` a valid electrode name?
         # Iterate through electrodes to find a matching name. Shuffle list
         # to reduce time complexity of average lookup.
-        for idx, electrode in randomly(enumerate(self.electrodes)):
+        for idx, electrode in traverse_randomly(enumerate(self.electrodes)):
             if electrode.name == name:
                 return idx
 

--- a/pulse2percept/electrode2currentmap.py
+++ b/pulse2percept/electrode2currentmap.py
@@ -702,7 +702,7 @@ class Psycho2Pulsetrain(TimeSeries):
                              "interval.")
         gap = np.zeros(gap_size)
 
-        pulse_train = []
+        pulse_train = np.array([])
         for j in range(int(np.round(dur * freq))):
             if pulseorder == 'pulsefirst':
                 pulse_train = np.concatenate((pulse_train, delay, pulse,

--- a/pulse2percept/electrode2currentmap.py
+++ b/pulse2percept/electrode2currentmap.py
@@ -856,6 +856,8 @@ class Retina(object):
         self.axon_weight = axon_weight
         self.jan_x = jan_x
         self.jan_y = jan_y
+        self.range_x = self.gridx.max() - self.gridx.min()
+        self.range_y = self.gridy.max() - self.gridy.min()
 
     def cm2ecm(self, cs):
         """

--- a/pulse2percept/files.py
+++ b/pulse2percept/files.py
@@ -58,3 +58,35 @@ def scale(inarray, newmin=0, newmax=1):
     delta = (newmax - newmin) / (oldmax - oldmin)
     outarray = delta * (inarray - oldmin) + newmin
     return outarray
+
+
+def find_files_like(datapath, pattern):
+    """Finds files in a folder whose name matches a pattern
+
+    This function looks for files in folder `datapath` that match a regular
+    expression `pattern`.
+
+    Parameters
+    ----------
+    datapath : str
+        Path to search
+    pattern : str
+        A valid regular expression pattern
+
+    Examples
+    --------
+    # Find all '.npz' files in parent dir
+    >>> files = find_files_like('..', '.*\.npz$')
+    """
+    # No need to import these at module level
+    from os import listdir
+    import re
+
+    # Traverse file list and look for `pattern`
+    filenames = []
+    pattern = re.compile(pattern)
+    for file in listdir(datapath):
+        if pattern.search(file):
+            filenames.append(file)
+
+    return filenames

--- a/pulse2percept/tests/test_electrode2currentmap.py
+++ b/pulse2percept/tests/test_electrode2currentmap.py
@@ -66,8 +66,8 @@ def test_ElectrodeArray():
         npt.assert_equal(el.radius, v)
         npt.assert_equal(el.x_center, v)
         npt.assert_equal(el.y_center, v)
-        npt.assert_equal(el.h_inl, v + 23 / 2)
-        npt.assert_equal(el.h_nfl, v + 83)
+        npt.assert_equal(el.h_inl, v + 23.0 / 2.0)
+        npt.assert_equal(el.h_nfl, v + 83.0)
 
 
 def test_ArgusI():

--- a/pulse2percept/tests/test_electrode2currentmap.py
+++ b/pulse2percept/tests/test_electrode2currentmap.py
@@ -98,20 +98,28 @@ def test_ArgusI():
     with pytest.raises(ValueError):
         e2cm.ArgusI(-100, 10, h=np.zeros(5))
 
-    # Indexing must work for both integers and electrode names
-    argus = e2cm.ArgusI()
-    for idx, electrode in enumerate(argus):
-        name = electrode.name
-        npt.assert_equal(electrode, argus[idx])
-        npt.assert_equal(electrode, argus[name])
-    npt.assert_equal(argus[16], None)
-    npt.assert_equal(argus["unlikely name for an electrode"], None)
+    for use_legacy_names in [False, True]:
+        # Indexing must work for both integers and electrode names
+        argus = e2cm.ArgusI(use_legacy_names=use_legacy_names)
+        for idx, electrode in enumerate(argus):
+            name = electrode.name
+            npt.assert_equal(electrode, argus[idx])
+            npt.assert_equal(electrode, argus[name])
+        npt.assert_equal(argus[16], None)
+        npt.assert_equal(argus["unlikely name for an electrode"], None)
 
-    # Indexing must have the right order
-    npt.assert_equal(argus.get_index('B1'), 1)
-    npt.assert_equal(argus['B1'], argus[1])
-    npt.assert_equal(argus.get_index('A2'), 4)
-    npt.assert_equal(argus['A2'], argus[4])
+        if use_legacy_names:
+            name_idx1 = 'L2'
+            name_idx4 = 'L5'
+        else:
+            name_idx1 = 'B1'
+            name_idx4 = 'A2'
+
+        # Indexing must have the right order
+        npt.assert_equal(argus.get_index(name_idx1), 1)
+        npt.assert_equal(argus[name_idx1], argus[1])
+        npt.assert_equal(argus.get_index(name_idx4), 4)
+        npt.assert_equal(argus[name_idx4], argus[4])
 
 
 def test_ArgusII():

--- a/pulse2percept/tests/test_electrode2currentmap.py
+++ b/pulse2percept/tests/test_electrode2currentmap.py
@@ -100,9 +100,10 @@ def test_ArgusI():
 
     # Indexing must work for both integers and electrode names
     argus = e2cm.ArgusI()
-    for idx, name in zip(range(16), argus.names):
-        npt.assert_equal(argus[idx], argus[name])
-        npt.assert_equal(argus[idx].name, name)
+    for idx, electrode in enumerate(argus):
+        name = electrode.name
+        npt.assert_equal(electrode, argus[idx])
+        npt.assert_equal(electrode, argus[name])
     npt.assert_equal(argus[16], None)
     npt.assert_equal(argus["unlikely name for an electrode"], None)
 
@@ -158,9 +159,10 @@ def test_ArgusII():
 
     # Indexing must work for both integers and electrode names
     argus = e2cm.ArgusII()
-    for idx, name in zip(range(60), argus.names):
-        npt.assert_equal(argus[idx], argus[name])
-        npt.assert_equal(argus[idx].name, name)
+    for idx, electrode in enumerate(argus):
+        name = electrode.name
+        npt.assert_equal(electrode, argus[idx])
+        npt.assert_equal(electrode, argus[name])
     npt.assert_equal(argus[60], None)
     npt.assert_equal(argus["unlikely name for an electrode"], None)
 

--- a/pulse2percept/tests/test_electrode2currentmap.py
+++ b/pulse2percept/tests/test_electrode2currentmap.py
@@ -22,6 +22,21 @@ def test_Electrode():
         # npt.assert_equal(e.h, hh)
         npt.assert_equal(e.etype, tt)
         npt.assert_equal(e.name, nn)
+        if tt.lower() == 'epiretinal':
+            # `height` property should return `h_nfl`
+            npt.assert_equal(e.height, e.h_nfl)
+
+            # `h_nfl` should be the same as the user-specified height
+            npt.assert_equal(e.height, hh)
+
+            # `h_inl` should be further away from the array
+            npt.assert_equal(e.h_inl > hh, True)
+        else:
+            # `height` property should return `h_inl`
+            npt.assert_equal(e.height, e.h_inl)
+
+            # Subretinal arrays have layer thicknesses added to `hh`.
+            npt.assert_equal(e.height > hh, True)
 
 
 def test_ElectrodeArray():

--- a/pulse2percept/tests/test_electrode2currentmap.py
+++ b/pulse2percept/tests/test_electrode2currentmap.py
@@ -238,6 +238,9 @@ def test_Retina_Electrodes():
                          sampling=sampling, save_data=False)
     npt.assert_equal(retina.gridx.shape, ((yhi - ylo) / sampling + 1,
                                           (xhi - xlo) / sampling + 1))
+    npt.assert_equal(retina.range_x, retina.gridx.max() - retina.gridx.min())
+    npt.assert_equal(retina.range_y, retina.gridy.max() - retina.gridy.min())
+
     electrode1 = e2cm.Electrode('epiretinal', 1, 0, 0, 0)
 
     # Calculate current spread for all retinal layers

--- a/pulse2percept/tests/test_files.py
+++ b/pulse2percept/tests/test_files.py
@@ -1,0 +1,13 @@
+from pulse2percept import files
+import numpy.testing as npt
+
+
+def test_find_files_like():
+    # Not sure how to check a valid pattern match, because we
+    # don't know in which directory the test suite is
+    # executed... so smoke test
+    files.find_files_like(".", ".*")
+
+    # Or fail to find an unlikely file name
+    filenames = files.find_files_like(".", "theresnowaythisexists\.xyz")
+    npt.assert_equal(filenames, [])

--- a/pulse2percept/tests/test_utils.py
+++ b/pulse2percept/tests/test_utils.py
@@ -59,3 +59,19 @@ def test_parfor():
     # If it's not reshaped, the first item should be the item 0, 0:
     npt.assert_equal(utils.parfor(power_it, my_list)[0],
                      power_it(my_array[0, 0]))
+
+
+def test_randomly():
+    # Generate a list of integers
+    sequence = np.arange(100).tolist()
+
+    # Iterate the sequence in random order
+    shuffled_idx = []
+    shuffled_val = []
+    for idx, value in enumerate(utils.randomly(sequence)):
+        shuffled_idx.append(idx)
+        shuffled_val.append(value)
+
+    # Make sure every element was visited once
+    npt.assert_equal(shuffled_idx, np.arange(len(sequence)).tolist())
+    npt.assert_equal(shuffled_val.sort(), sequence.sort())

--- a/pulse2percept/tests/test_utils.py
+++ b/pulse2percept/tests/test_utils.py
@@ -75,14 +75,3 @@ def test_randomly():
     # Make sure every element was visited once
     npt.assert_equal(shuffled_idx, np.arange(len(sequence)).tolist())
     npt.assert_equal(shuffled_val.sort(), sequence.sort())
-
-
-def test_find_files_like():
-    # Not sure how to check a valid pattern match, because we
-    # don't know in which directory the test suite is
-    # executed... so smoke test
-    utils.find_files_like(".", ".*")
-
-    # Or fail to find an unlikely file name
-    files = utils.find_files_like(".", "theresnowaythisexists\.xyz")
-    npt.assert_equal(files, [])

--- a/pulse2percept/tests/test_utils.py
+++ b/pulse2percept/tests/test_utils.py
@@ -61,14 +61,14 @@ def test_parfor():
                      power_it(my_array[0, 0]))
 
 
-def test_randomly():
+def test_traverse_randomly():
     # Generate a list of integers
     sequence = np.arange(100).tolist()
 
     # Iterate the sequence in random order
     shuffled_idx = []
     shuffled_val = []
-    for idx, value in enumerate(utils.randomly(sequence)):
+    for idx, value in enumerate(utils.traverse_randomly(sequence)):
         shuffled_idx.append(idx)
         shuffled_val.append(value)
 

--- a/pulse2percept/tests/test_utils.py
+++ b/pulse2percept/tests/test_utils.py
@@ -75,3 +75,14 @@ def test_randomly():
     # Make sure every element was visited once
     npt.assert_equal(shuffled_idx, np.arange(len(sequence)).tolist())
     npt.assert_equal(shuffled_val.sort(), sequence.sort())
+
+
+def test_find_files_like():
+    # Not sure how to check a valid pattern match, because we
+    # don't know in which directory the test suite is
+    # executed... so smoke test
+    utils.find_files_like(".", ".*")
+
+    # Or fail to find an unlikely file name
+    files = utils.find_files_like(".", "theresnowaythisexists\.xyz")
+    npt.assert_equal(files, [])

--- a/pulse2percept/utils.py
+++ b/pulse2percept/utils.py
@@ -3,6 +3,7 @@ Utility functions for pulse2percept
 """
 import numpy as np
 import multiprocessing
+import random
 
 try:
     from numba import jit
@@ -277,3 +278,24 @@ def memory_usage():
         if status is not None:
             status.close()
     return result
+
+
+def randomly(seq):
+    """Traverses a list in random order
+
+    Parameters
+    ----------
+    seq : list
+        An iterable list of elements.
+
+    Notes
+    -----
+    From: http://stackoverflow.com/a/9253366
+    Note that even for rather small `len(x)`, the total number of permutations
+    of `seq` can quickly grow larger than the period of most random number
+    generators. For example, a sequence of length 2080 is the largest that can
+    fit within the period of the Mersenne Twister random number generator.
+    """
+    shuffled = list(seq)
+    random.shuffle(shuffled)
+    return iter(shuffled)

--- a/pulse2percept/utils.py
+++ b/pulse2percept/utils.py
@@ -282,35 +282,3 @@ def randomly(seq):
     random.shuffle(shuffled)
 
     return iter(shuffled)
-
-
-def find_files_like(datapath, pattern):
-    """Finds files in a folder whose name matches a pattern
-
-    This function looks for files in folder `datapath` that match a regular
-    expression `pattern`.
-
-    Parameters
-    ----------
-    datapath : str
-        Path to search
-    pattern : str
-        A valid regular expression pattern
-
-    Examples
-    --------
-    # Find all '.npz' files in parent dir
-    >>> files = find_files_like('..', '.*\.npz$')
-    """
-    # No need to import these at module level
-    from os import listdir
-    import re
-
-    # Traverse file list and look for `pattern`
-    filenames = []
-    pattern = re.compile(pattern)
-    for file in listdir(datapath):
-        if pattern.search(file):
-            filenames.append(file)
-
-    return filenames

--- a/pulse2percept/utils.py
+++ b/pulse2percept/utils.py
@@ -259,13 +259,27 @@ def mov2npy(movie_file, out_file):
     np.save(out_file, frames)
 
 
-def randomly(seq):
+def traverse_randomly(seq):
     """Traverses a list in random order
 
     Parameters
     ----------
     seq : list
         An iterable list of elements.
+    Returns
+    -------
+    A list iterator.
+
+    Examples
+    --------
+    Shuffle a list:
+    >>> list_ordered = [0, 1, 2, 3]
+    >>> list_shuffled = [l for l in traverse_randomly(list_ordered)]
+
+    Traverse a list in random order:
+    >>> list_ordered = [0, 1, 2, 3]
+    >>> for idx, val in traverse_randomly(enumerate(list_ordered)):
+    ...     pass
 
     Notes
     -----

--- a/pulse2percept/utils.py
+++ b/pulse2percept/utils.py
@@ -5,6 +5,7 @@ import numpy as np
 import multiprocessing
 import random
 
+
 try:
     from numba import jit
     has_jit = True
@@ -258,28 +259,6 @@ def mov2npy(movie_file, out_file):
     np.save(out_file, frames)
 
 
-def memory_usage():
-    """Memory usage of the current process in kilobytes.
-
-    This works only on systems with a /proc file system
-    (like Linux).
-    http://stackoverflow.com/questions/897941/python-equivalent-of-phps-memory-get-usage/7669279
-    """
-    status = None
-    result = {'peak': 0, 'rss': 0}
-    try:
-        status = open('/proc/self/status')
-        for line in status:
-            parts = line.split()
-            key = parts[0][2:-1].lower()
-            if key in result:
-                result[key] = int(parts[1])
-    finally:
-        if status is not None:
-            status.close()
-    return result
-
-
 def randomly(seq):
     """Traverses a list in random order
 
@@ -296,6 +275,42 @@ def randomly(seq):
     generators. For example, a sequence of length 2080 is the largest that can
     fit within the period of the Mersenne Twister random number generator.
     """
+    # Make sure we are dealing with a list
     shuffled = list(seq)
+
+    # Import `random` at module level (for performance)
     random.shuffle(shuffled)
+
     return iter(shuffled)
+
+
+def find_files_like(datapath, pattern):
+    """Finds files in a folder whose name matches a pattern
+
+    This function looks for files in folder `datapath` that match a regular
+    expression `pattern`.
+
+    Parameters
+    ----------
+    datapath : str
+        Path to search
+    pattern : str
+        A valid regular expression pattern
+
+    Examples
+    --------
+    # Find all '.npz' files in parent dir
+    >>> files = find_files_like('..', '.*\.npz$')
+    """
+    # No need to import these at module level
+    from os import listdir
+    import re
+
+    # Traverse file list and look for `pattern`
+    filenames = []
+    pattern = re.compile(pattern)
+    for file in listdir(datapath):
+        if pattern.search(file):
+            filenames.append(file)
+
+    return filenames


### PR DESCRIPTION
A few improvements for the ElectrodeArray class and some helper functions. Most of these are already being used in my experiment branches in one form or the other, but are now also tested and integrated. So the purpose of their existence is mostly to make my life easier. 😸 

Argus I arrays now support legacy naming (L1, L2, ..., L8, M1, M2, ..., M8).

The electrode-to-retina distance depends on electrode type and electrode location. This computation has been moved to `Electrode.set_height` so that heights can be overridden.

Keeping track of electrode names in `ElectrodeArray.names` is redundant, because every `Electrode` has a `name` itself. Setting custom (or new) names would have to be done in both places, otherwise indexing might break. Therefore, I removed `ElectrodeArray.names`. In order to do the indexing, the loop has to be over `name` of every `Electrode` in an `ElectrodeArray`. In order to speed up the average lookup time, the array is traversed in random order.

The parameter `tol` of `pulse2percept` now specifies a fraction instead of an absolute value: For example, `tol=0.1` will discard all pixels whose effective current is <10% of the max effective current value.

I also added a helper function that can find files in a directory whose names match a regular expression pattern.