### PR TITLE
Add Stimulus object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # simple makefile to simplify repetitive build env management tasks under posix
 
 PIP ?= pip3
+PYTHON ?= python3
 PYTEST ?= pytest
 FLAKE ?= flake8
 
@@ -23,7 +24,7 @@ doc: install
 	$(MAKE) -C doc html
 
 tests: install
-	$(PYTEST) --showlocals -v pulse2percept --durations=20
+	$(PYTEST) --doctest-modules --showlocals -v pulse2percept --durations=20
 
 flake:
 	$(FLAKE) --ignore N802,N806,W504 --select W503 `find . -name \*.py | grep -v setup.py | grep -v __init__.py | grep -v /doc/`

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,7 +39,9 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx_gallery.gen_gallery',
-    'sphinx.ext.autosummary'
+    'sphinx.ext.autosummary',
+    'IPython.sphinxext.ipython_directive',
+    'IPython.sphinxext.ipython_console_highlighting',
 ]
 
 # this is needed for some reason...
@@ -57,8 +59,6 @@ else:
     mathjax_path = ('https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/'
                     'MathJax.js?config=TeX-AMS_SVG')
 
-
-# autodoc_default_flags = ['members', 'inherited-members']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/developers/tests.rst
+++ b/doc/developers/tests.rst
@@ -6,3 +6,7 @@ Tests
 TODO
 
 Explain how to write test cases and how to run the test suite.
+
+Note: Print statements in your tests will show up only if one of the tests fails.
+The easiest way to make a test fail is to temporarily add `npt.assert_equal(True, False)`
+to the end of it.

--- a/doc/first_steps.rst
+++ b/doc/first_steps.rst
@@ -1,0 +1,4 @@
+First steps
+===========
+
+TODO

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -1,4 +1,0 @@
-Getting started
-===============
-
-TODO

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,11 +5,15 @@ Welcome to pulse2percept, a Python-based simulation framework for bionic vision.
 
 For more information, see https://github.com/uwescience/pulse2percept.
 
+Documentation
+-------------
+
 .. toctree::
+   :caption: Getting Started
    :maxdepth: 2
 
    installation
-   getting_started
+   first_steps
    background
    auto_examples/index
 
@@ -21,9 +25,6 @@ For more information, see https://github.com/uwescience/pulse2percept.
    users/index
    developers/index
    reference/index
-
-
-
 
 .. figure:: _static/eScience_Logo_HR.png
    :align: center

--- a/doc/users/index.rst
+++ b/doc/users/index.rst
@@ -10,5 +10,6 @@ Have a look at the following topics:
 .. toctree::
    :numbered:
 
-   models
+   stimuli
    implants
+   models

--- a/doc/users/stimuli.rst
+++ b/doc/users/stimuli.rst
@@ -1,0 +1,150 @@
+Creating stimuli
+================
+
+.. ipython:: python
+    :suppress:
+
+    # Use defaults so we don't get gridlines in generated docs
+    import matplotlib as mpl
+    
+    mpl.rcdefaults()
+
+The `Stimulus` object defines a common interface for all electrical stimuli.
+It basically provides a 2-D data array with labeled axes, where rows denote electrodes and columns denote points in time.
+Stimuli can be assigned to electrodes of a `ProsthesisSystem` object, who will deliver them to the retina.
+
+A stimulus can be created from a variety of source types, such as the following:
+
+* Scalar value: interpreted as the current amplitude delivered to a single electrode (no time component).
+* NumPy array:
+   * Nx1 array: interpreted as N current amplitudes delivered to N electrodes (no time component).
+   * NxM array: interpreted as N electrodes each receiving M current amplitudes in time.
+* `TimeSeries`: interpreted as the stimulus in time for a single electrode (e.g., `PulseTrain`).
+
+In addition, you can also pass a collection of source types (e.g., list, dictionary).
+
+See the `Stimulus` API documentation for a full list.
+
+.. note::
+   Depending on the source type, a stimulus might have a time component or not.
+
+Single-electrode stimuli
+------------------------
+
+The easiest way to create a stimulus is to specify the current amplitude (uA) to be delivered to an electrode:
+
+.. ipython:: python
+
+    from pulse2percept.stimuli import Stimulus
+
+    # Stimulate an unnamed electrode with -14uA:
+    Stimulus(-14)
+
+You can also specify the name of the electrode to be stimulated:
+
+.. ipython:: python
+
+    # Stimulate Electrode 'B7' with -14uA:
+    Stimulus(-14, electrodes='B7')
+    
+By default, this stimulus will not have a time component (`stim.time` is None).
+Some models, such as `ScoreboardModel`, cannot handle stimuli in time.
+
+To create stimuli in time, you can pass a `TimeSeries` object, such as a `BiphasicPulse` or a `PulseTrain`:
+
+.. ipython:: python
+
+    # Stimulate Electrode 'A001' with a cathodic-first 20Hz pulse train
+    # with 10uA amplitude, lasting for 0.5s, sampled at 0.1ms:
+    from pulse2percept.stimuli import PulseTrain
+    pt = PulseTrain(0.0001, freq=20, amp=10, dur=0.5)
+    stim = Stimulus(pt)
+    stim
+
+    # This stimulus has a time component:
+    stim.time
+
+Note that the `Stimulus` object automatically compresses the data.
+That is, rather than saving the current amplitude at every 0.1ms time step, only the non-redundant values are retained.
+You can convince yourself of that by inspecting the size of the two objects:
+
+.. ipython:: python
+
+    pt.shape
+
+    stim.shape
+
+You can specify not only the name of the electrode but also the time steps to be used:
+
+.. ipython:: python
+
+   # Stimulate Electrode 'C7' with int time steps:
+   Stimulus(pt, electrodes='C7', time=np.arange(pt.shape[-1]))
+
+.. note::
+    You can disable this compression by passing `sparsify=False` to `Stimulus`.
+
+Creating multi-electrode stimuli
+--------------------------------
+
+Stimuli can also be created from a list or dictionary of source types:
+
+.. ipython:: python
+
+    # Stimulate three unnamed electrodes with -2uA, 14uA, and -100uA, respectively:
+    Stimulus([-2, 14, -100])
+
+Electrode names can be passed in a list:
+
+.. ipython:: python
+
+    Stimulus([-2, 14, -100], electrodes=['A1', 'B1', 'C1'])
+
+Alternatively, stimuli can be created from a dictionary:
+
+.. ipython:: python
+
+    # Equivalent to the previous one:
+    Stimulus({'A1': -2, 'B1': 14, 'C1': -100})
+
+The same is true for a dictionary of pulse trains:
+
+.. ipython:: python
+
+    # Sending the same pulse train to three specific electrodes:
+    Stimulus({'A1': pt, 'B1': pt, 'C1': pt})
+
+Miscellaneous
+-------------
+
+Assigning new coordinates to an existing stimulus
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can change the coordinates of an existing `Stimulus` object, but retain all its data,
+as follows:
+
+.. ipython:: python
+
+    # Say you have a Stimulus object with unlabeled axes:
+    stim = Stimulus(np.ones((2, 5)))
+    stim
+
+    # You can create a new object from it with named electrodes:
+    Stimulus(stim, electrodes=['A1', 'F10'])
+
+    # Same goes for time points (but note it's been compressed):
+    Stimulus(stim, time=[0, 0.1])
+
+Compressing an uncompressed stimulus
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can compress an uncompressed stimulus as follows:
+
+.. ipython:: python
+
+    # Say you have an uncompressed stimulus:
+    stim = Stimulus(PulseTrain(0.0001, freq=10), sparsify=False)
+    stim
+
+    # You can create a new oject from it with compressed data:
+    Stimulus(stim, sparsify=True)

--- a/doc/users/stimuli.rst
+++ b/doc/users/stimuli.rst
@@ -10,8 +10,8 @@ Creating stimuli
     mpl.rcdefaults()
 
 The `Stimulus` object defines a common interface for all electrical stimuli.
-It basically provides a 2-D data array with labeled axes, where rows denote electrodes and columns denote points in time.
-Stimuli can be assigned to electrodes of a `ProsthesisSystem` object, who will deliver them to the retina.
+It provides a 2-D data array with labeled axes, where rows denote electrodes and columns denote points in time.
+Stimuli can be assigned to electrodes of a :class:`pulse2percept.implants.ProsthesisSystem` object, who will deliver them to the retina.
 
 A stimulus can be created from a variety of source types, such as the following:
 
@@ -19,11 +19,11 @@ A stimulus can be created from a variety of source types, such as the following:
 * NumPy array:
    * Nx1 array: interpreted as N current amplitudes delivered to N electrodes (no time component).
    * NxM array: interpreted as N electrodes each receiving M current amplitudes in time.
-* `TimeSeries`: interpreted as the stimulus in time for a single electrode (e.g., `PulseTrain`).
+* :class:`pulse2percept.utils.TimeSeries`: interpreted as the stimulus in time for a single electrode (e.g., `PulseTrain`).
 
 In addition, you can also pass a collection of source types (e.g., list, dictionary).
 
-See the `Stimulus` API documentation for a full list.
+See the :class:`pulse2percept.stimuli.Stimulus` API documentation for a full list.
 
 .. note::
    Depending on the source type, a stimulus might have a time component or not.
@@ -48,9 +48,9 @@ You can also specify the name of the electrode to be stimulated:
     Stimulus(-14, electrodes='B7')
     
 By default, this stimulus will not have a time component (`stim.time` is None).
-Some models, such as `ScoreboardModel`, cannot handle stimuli in time.
+Some models, such as :class:`pulse2percept.models.ScoreboardModel`, cannot handle stimuli in time.
 
-To create stimuli in time, you can pass a `TimeSeries` object, such as a `BiphasicPulse` or a `PulseTrain`:
+To create stimuli in time, you can pass a :class:`pulse2percept.utils.TimeSeries` object, such as a :class:`pulse2percept.stimuli.BiphasicPulse` or a :class:`pulse2percept.stimuli.PulseTrain`:
 
 .. ipython:: python
 
@@ -104,7 +104,7 @@ The same is true for a dictionary of pulse trains:
 Assigning new coordinates to an existing stimulus
 -------------------------------------------------
 
-You can change the coordinates of an existing `Stimulus` object, but retain all its data,
+You can change the coordinates of an existing `:class:`pulse2percept.stimuli.Stimulus` object, but retain all its data,
 as follows:
 
 .. ipython:: python

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -2,18 +2,18 @@
 import numpy as np
 import abc
 import collections as coll
-import xarray as xr
 
+from ..stimuli import Stimulus
 from ..utils import PrettyPrint
 
 
 class Electrode(PrettyPrint):
+    """Electrode
+
+    Abstract base class for all electrodes.
+    """
 
     def __init__(self, x, y, z):
-        """Electrode
-
-        Abstract base class for all electrodes.
-        """
         if isinstance(x, (coll.Sequence, np.ndarray)):
             raise TypeError("x must be a scalar.")
         if isinstance(y, (coll.Sequence, np.ndarray)):
@@ -44,18 +44,17 @@ class PointSource(Electrode):
 
 
 class DiskElectrode(Electrode):
-    """Circular disk electrode"""
+    """Circular disk electrode
+
+    Parameters
+    ----------
+    x, y, z : double
+        3D location that is the center of the disk electrode
+    r : double
+        Disk radius in the x,y plane
+    """
 
     def __init__(self, x, y, z, r):
-        """Circular disk electrode
-
-        Parameters
-        ----------
-        x, y, z : double
-            3D location that is the center of the disk electrode
-        r : double
-            Disk radius in the x,y plane
-        """
         super(DiskElectrode, self).__init__(x, y, z)
         if isinstance(r, (coll.Sequence, np.ndarray)):
             raise TypeError("Electrode radius must be a scalar.")
@@ -195,67 +194,185 @@ class ElectrodeArray(PrettyPrint):
 
 
 class ProsthesisSystem(PrettyPrint):
+    """Visual prosthesis system
+
+    A visual prosthesis combines an electrode array and (optionally) a
+    stimulus. This is the base class for prosthesis systems such as `ArgusII`
+    and `AlphaIMS`.
+
+    Parameters
+    ----------
+    earray : `ElectrodeArray` or `Electrode`
+        The electrode array used to deliver electrical stimuli to the retina.
+    stim : `Stimulus` source type
+        A valid source type for the `Stimulus` object (e.g., scalar, NumPy
+        array, pulse train).
+    eye : 'LE' or 'RE'
+        A string indicating whether the system is implanted in the left ('LE')
+        or right eye ('RE')
+
+    Examples
+    --------
+    A system in the left eye made from a single DiskElectrode with radius
+    r=100um sitting at x=200um, y=-50um, z=10um:
+
+    >>> from pulse2percept.implants import DiskElectrode, ProsthesisSystem
+    >>> implant = ProsthesisSystem(DiskElectrode(200, -50, 10, 100), eye='LE')
+
+    .. note::
+       A stimulus can also be assigned later (see `stim`).
+    """
 
     def __init__(self, earray, stim=None, eye='RE'):
-        """ProsthesisSystem
-
-        A visual prosthesis that combines an electrode array and a stimulus.
-        """
-        if not isinstance(earray, ElectrodeArray):
-            raise TypeError("'earray' must be an ElectrodeArray object, not "
-                            "%s." % type(earray))
         self.earray = earray
         self.stim = stim
-        if eye not in ['LE', 'RE']:
-            raise ValueError("'eye' must be either 'LE' or 'RE', not "
-                             "%s." % eye)
         self.eye = eye
 
     def get_params(self):
         return {'earray': self.earray, 'stim': self.stim, 'eye': self.eye}
 
+    def check_stim(self, stim):
+        """Quality-check the stimulus
+
+        This method is executed every time a new value is assigned to `stim`.
+
+        No checks are performed by default, but the user can define their own
+        checks in implants that inherit from `ProsthesisSystem`.
+
+        Parameters
+        ----------
+        stim : `Stimulus` source type
+            A valid source type for the `Stimulus` object (e.g., scalar, NumPy
+            array, pulse train).
+        """
+        pass
+
+    @property
+    def earray(self):
+        """Electrode array
+
+        """
+        return self._earray
+
+    @earray.setter
+    def earray(self, earray):
+        """Electrode array setter (called upon `self.earray = earray`)"""
+        # Assign the electrode array:
+        if isinstance(earray, Electrode):
+            # For convenience, build an array froma single electrode:
+            earray = ElectrodeArray(earray)
+        if not isinstance(earray, ElectrodeArray):
+            raise TypeError("'earray' must be an ElectrodeArray object, not "
+                            "%s." % type(earray))
+        self._earray = earray
+
     @property
     def stim(self):
-        """Stimulus"""
+        """Stimulus
+
+        A stimulus can be created from many source types, such as scalars,
+        NumPy arrays, and dictionaries (see `Stimulus` for a complete list).
+
+        A stimulus can be assigned either in the `ProsthesisSystem` constructor
+        or later by assigning a value to `stim`.
+
+        .. note::
+           Unless when using dictionary notation, the number of stimuli must
+           equal the number of electrodes in `earray`.
+
+        Examples
+        --------
+        Send a biphasic pulse to an implant made from a single `DiskElectrode`:
+
+        >>> form pulse2percept.implants import DiskElectrode, ProsthesisSystem
+        >>> from pulse2percept.stimuli import BiphasicPulse
+        >>> implant = ProsthesisSystem(DiskElectrode(0, 0, 0, 100))
+        >>> implant.stim = BiphasicPulse('cathodicfirst', 1e-4, 1e-6)
+
+        Stimulate Electrode B7 in Argus II with 13 uA:
+
+        >>> from pulse2percept.implants import ArgusII
+        >>> implant = ArgusII(stim={'B7': 13})
+
+        """
         return self._stim
 
     @stim.setter
     def stim(self, data):
+        """Stimulus setter (called upon `self.stim = data`)"""
         if data is None:
             self._stim = None
-        elif isinstance(data, np.ndarray):
-            if data.size != self.earray.n_electrodes:
-                raise ValueError(("NumPy array must have the same number of "
-                                  "elements as the implant has electrodes "
-                                  "(%d), not %d.") % (self.earray.n_electrodes,
-                                                      data.size))
-            # Convert to double
-            data = np.asarray(data, dtype=np.double)
-            # Find all nonzero entries:
-            idx_nz = np.flatnonzero(data)
-            # Make sure these are valid indexes into the electrode array:
-            electrodes = self.earray[idx_nz]
-            # Set these as coordinates:
-            coords = [('electrodes', electrodes)]
-            # Retain only nonzero data:
-            self._stim = xr.DataArray(data.ravel()[idx_nz], coords=coords,
-                                      name='current (uA)')
         else:
-            raise NotImplementedError
+            # Use electrode names as stimulus coordinates:
+            stim = Stimulus(data, electrodes=list(self.earray.keys()))
+            # Perform safety checks, etc.:
+            self.check_stim(stim)
+            # Store safe stimulus:
+            self._stim = stim
+
+    @property
+    def eye(self):
+        """Implanted eye
+
+        A `ProsthesisSystem` can be implanted either in a left eye ('LE') or
+        right eye ('RE'). Models such as `AxonMapModel` will treat left and
+        right eyes differently (for example, adjusting the location of the
+        optic disc).
+
+        Examples
+        --------
+        Implant Argus II in a left eye:
+
+        >>> from pulse2percept.implants import ArgusII
+        >>> implant = ArgusII(eye='LE')
+        """
+        return self._eye
+
+    @eye.setter
+    def eye(self, eye):
+        """Eye setter (called upon `self.eye = eye`)"""
+        if eye not in ['LE', 'RE']:
+            raise ValueError("'eye' must be either 'LE' or 'RE', not "
+                             "%s." % eye)
+        self._eye = eye
 
     @property
     def n_electrodes(self):
-        """Number of electrodes in the array"""
+        """Number of electrodes in the array
+
+        This is equivalent to calling `earray.n_electrodes`.
+        """
         return self.earray.n_electrodes
 
     def __getitem__(self, item):
         return self.earray[item]
 
+    def __iter__(self):
+        return iter(self.earray)
+
     def keys(self):
+        """Return all electrode names in the electrode array"""
         return self.earray.keys()
 
     def values(self):
+        """Return all electrode objects in the electrode array"""
         return self.earray.values()
 
     def items(self):
+        """Return all electrode names and objects in the electrode array
+
+        Internally, electrodes are stored in a dictionary in
+        `earray.electrodes`. For convenience, electrodes can also be accessed
+        via `items`.
+
+        Examples
+        --------
+        Save the x-coordinates of all electrodes of Argus I in a dictionary:
+
+        >>> from pulse2percept.implants import ArgusI
+        >>> xcoords = {}
+        >>> for name, electrode in ArgusI():
+        ...     xcoords[name] = electrode.x
+
+        """
         return self.earray.items()

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -284,7 +284,7 @@ class ProsthesisSystem(PrettyPrint):
         --------
         Send a biphasic pulse to an implant made from a single `DiskElectrode`:
 
-        >>> form pulse2percept.implants import DiskElectrode, ProsthesisSystem
+        >>> from pulse2percept.implants import DiskElectrode, ProsthesisSystem
         >>> from pulse2percept.stimuli import BiphasicPulse
         >>> implant = ProsthesisSystem(DiskElectrode(0, 0, 0, 100))
         >>> implant.stim = BiphasicPulse('cathodicfirst', 1e-4, 1e-6)
@@ -303,8 +303,12 @@ class ProsthesisSystem(PrettyPrint):
         if data is None:
             self._stim = None
         else:
-            # Use electrode names as stimulus coordinates:
-            stim = Stimulus(data, electrodes=list(self.earray.keys()))
+            if isinstance(data, dict):
+                # Electrode names already provided by keys:
+                stim = Stimulus(data)
+            else:
+                # Use electrode names as stimulus coordinates:
+                stim = Stimulus(data, electrodes=list(self.earray.keys()))
             # Perform safety checks, etc.:
             self.check_stim(stim)
             # Store safe stimulus:
@@ -371,7 +375,7 @@ class ProsthesisSystem(PrettyPrint):
 
         >>> from pulse2percept.implants import ArgusI
         >>> xcoords = {}
-        >>> for name, electrode in ArgusI():
+        >>> for name, electrode in ArgusI().items():
         ...     xcoords[name] = electrode.x
 
         """

--- a/pulse2percept/implants/tests/test_argus.py
+++ b/pulse2percept/implants/tests/test_argus.py
@@ -91,6 +91,16 @@ def test_ArgusI(ztype, x, y, r):
     npt.assert_equal(argus.get_old_name('B2'), 'L1')
     npt.assert_equal(argus.get_old_name('A1'), 'L6')
 
+    # Set a stimulus via dict:
+    argus = implants.ArgusI(stim={'B3': 13})
+    npt.assert_equal(argus.stim.shape, (1, 1))
+    npt.assert_equal(argus.stim.electrodes, ['B3'])
+
+    # Set a stimulus via array:
+    argus = implants.ArgusI(stim=np.ones(16))
+    npt.assert_equal(argus.stim.shape, (16, 1))
+    npt.assert_almost_equal(argus.stim.data, 1)
+
 
 @pytest.mark.parametrize('ztype', ('float', 'list'))
 @pytest.mark.parametrize('x', (-100, 200))
@@ -162,3 +172,13 @@ def test_ArgusII(ztype, x, y, r):
         after = implants.ArgusII(eye=eye, rot=np.deg2rad(10))
         npt.assert_equal(after[el].x < before[el].x, True)
         npt.assert_equal(after[el].y > before[el].y, True)
+
+    # Set a stimulus via dict:
+    argus = implants.ArgusII(stim={'B7': 13})
+    npt.assert_equal(argus.stim.shape, (1, 1))
+    npt.assert_equal(argus.stim.electrodes, ['B7'])
+
+    # Set a stimulus via array:
+    argus = implants.ArgusII(stim=np.ones(60))
+    npt.assert_equal(argus.stim.shape, (60, 1))
+    npt.assert_almost_equal(argus.stim.data, 1)

--- a/pulse2percept/io/video.py
+++ b/pulse2percept/io/video.py
@@ -192,8 +192,7 @@ def load_video(filename, as_timeseries=True, as_gray=False, ffmpeg_path=None,
         backend = 'libav'
     video = svio.vread(filename, as_grey=as_gray, backend=backend)
     logging.getLogger(__name__).info("Loaded video from file '%s'." % filename)
-    d_s = "Loaded video has shape (T, M, N, C) = " + str(video.shape)
-    logging.getLogger(__name__).debug(d_s)
+    d_s = "Loaded video has shape (T, M, N, C) = " + str(video.shape) 
 
     if as_timeseries:
         # TimeSeries has the time as the last dimensions: re-order dimensions,
@@ -201,8 +200,7 @@ def load_video(filename, as_timeseries=True, as_gray=False, ffmpeg_path=None,
         axes = np.roll(range(video.ndim), -1)
         video = np.squeeze(np.transpose(video, axes=axes))
         fps = load_video_framerate(filename)
-        d_s = "Reshaped video to shape (M, N, C, T) = " + str(video.shape)
-        logging.getLogger(__name__).debug(d_s)
+        d_s = "Reshaped video to shape (M, N, C, T) = " + str(video.shape) 
         return TimeSeries(1.0 / fps, video)
     else:
         # Return as ndarray
@@ -337,12 +335,10 @@ def save_video(data, filename, width=None, height=None, fps=30,
         # Resample the percept to the given frame rate
         new_tsample = 1.0 / float(fps)
         d_s = 'old: tsample=%f' % data.tsample
-        d_s += ', shape=' + str(data.shape)
-        logging.getLogger(__name__).debug(d_s)
+        d_s += ', shape=' + str(data.shape) 
         data = data.resample(new_tsample)
         d_s = 'new: tsample=%f' % new_tsample
         d_s += ', shape=' + str(data.shape)
-        logging.getLogger(__name__).debug(d_s)
         oldheight = data.shape[0]
         oldwidth = data.shape[1]
         length = data.shape[-1]
@@ -355,8 +351,7 @@ def save_video(data, filename, width=None, height=None, fps=30,
         width = int(height * 1.0 / oldheight * oldwidth)
     elif width and not height:
         height = int(width * 1.0 / oldwidth * oldheight)
-    d_s = "Video scaled to (M, N, T) = (%d, %d, %d)." % (height, width, length)
-    logging.getLogger(__name__).debug(d_s)
+    d_s = "Video scaled to (M, N, T) = (%d, %d, %d)." % (height, width, length) 
 
     # Reshape and scale the data
     savedata = np.zeros((length, height, width, 3), dtype=np.float32)

--- a/pulse2percept/models/axon_map.py
+++ b/pulse2percept/models/axon_map.py
@@ -336,10 +336,10 @@ class AxonMapModel(Watson2014ConversionMixin, BaseModel):
         if axon.shape[0] == 0:
             return 0.0
         # Calculate the brightness at pixel:
-        electrodes = implant.stim.coords['electrodes'].values
-        bright = axon_map(implant.stim.data,
-                          np.array([e.x for e in electrodes]),
-                          np.array([e.y for e in electrodes]),
+        electrodes = implant.stim.electrodes
+        bright = axon_map(implant.stim.data[:, 0],
+                          np.array([implant[e].x for e in electrodes]),
+                          np.array([implant[e].y for e in electrodes]),
                           axon,
                           self.rho,
                           self.thresh_percept)

--- a/pulse2percept/models/base.py
+++ b/pulse2percept/models/base.py
@@ -197,6 +197,19 @@ class BaseModel(Frozen, PrettyPrint, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     def predict_percept(self, implant, t=None):
+        """Predict a percept
+
+        Parameters
+        ----------
+        implant : `ProsthesisSystem`
+            Stimulus can be passed via
+            :py:meth:`~pulse2percept.implants.ProsthesisSystem.stim`.
+        fps : int, double
+            Frames per second at which the percept should be rendered.
+        n_frames : int
+            If None, will simulate for the duration of the stimulus plus one
+            frame (rounding up).
+        """
         if not self._is_built:
             raise NotBuiltError("Yout must call ``build`` first.")
         if not isinstance(implant, ProsthesisSystem):
@@ -205,7 +218,12 @@ class BaseModel(Frozen, PrettyPrint, metaclass=abc.ABCMeta):
         if implant.stim is None:
             # Nothing to see here:
             return None
+        if implant.stim.time is not None:
+            # The stimulus has a time dimension
+            raise NotImplementedError
 
+        # The stimulus does not have a time dimesnion. In this case, we
+        # only need to run the spatial model:
         return parfor(self._predict_pixel_percept,
                       enumerate(self.grid),
                       func_args=[implant],

--- a/pulse2percept/models/scoreboard.py
+++ b/pulse2percept/models/scoreboard.py
@@ -26,10 +26,10 @@ class ScoreboardModel(Watson2014ConversionMixin, BaseModel):
         """
         idx_xy, xydva = xygrid
         # Call the Cython function for fast processing:
-        electrodes = implant.stim.coords['electrodes'].values
-        bright = scoreboard(implant.stim.data,
-                            np.array([e.x for e in electrodes]),
-                            np.array([e.y for e in electrodes]),
+        electrodes = implant.stim.electrodes
+        bright = scoreboard(implant.stim.data[:, 0],
+                            np.array([implant[e].x for e in electrodes]),
+                            np.array([implant[e].y for e in electrodes]),
                             *self.get_tissue_coords(*xydva),
                             self.rho,
                             self.thresh_percept)

--- a/pulse2percept/models/tests/test_axon_map.py
+++ b/pulse2percept/models/tests/test_axon_map.py
@@ -26,7 +26,7 @@ def test_AxonMapModel():
         npt.assert_equal(getattr(model, key), value)
 
     # Zeros in, zeros out:
-    implant = implants.ArgusII(stim=np.zeros((6, 10)))
+    implant = implants.ArgusII(stim=np.zeros(60))
     npt.assert_almost_equal(model.predict_percept(implant), 0)
     implant.stim = np.zeros(60)
     npt.assert_almost_equal(model.predict_percept(implant), 0)
@@ -150,8 +150,8 @@ def test_AxonMapModel_predict_percept():
     model = models.AxonMapModel(xystep=1, axlambda=100, thresh_percept=0)
     model.build()
     # Single-electrode stim:
-    img_stim = np.zeros((6, 10))
-    img_stim[4, 7] = 1
+    img_stim = np.zeros(60)
+    img_stim[47] = 1
     percept = model.predict_percept(implants.ArgusII(stim=img_stim))
     # Single bright pixel, rest of arc is less bright:
     npt.assert_equal(np.sum(percept > 0.9), 1)
@@ -171,7 +171,7 @@ def test_AxonMapModel_predict_percept():
     model = models.AxonMapModel(engine='serial', xystep=1, rho=100,
                                 axlambda=40)
     model.build()
-    percept = model.predict_percept(implants.ArgusII(stim=np.ones((6, 10))))
+    percept = model.predict_percept(implants.ArgusII(stim=np.ones(60)))
     # Most spots are pretty bright, but there are 2 dimmer ones (due to their
     # location on the retina):
     npt.assert_equal(np.sum(percept > 0.5), 58)

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -125,11 +125,6 @@ def test_BaseModel_predict_percept():
     # None in, None out:
     npt.assert_equal(model.predict_percept(implants.ArgusII(stim=None)), None)
 
-    # `predict` only accepts NumPy arrays
-    for XX in [42, [3.3, 1.1], {'img': [[2]]}]:
-        with pytest.raises(ValueError):
-            implants.ArgusII(stim=XX)
-
     # `img_stim` must have right size:
     for shape in [(2, 60), (59,), (2, 3, 4)]:
         with pytest.raises(ValueError):

--- a/pulse2percept/models/tests/test_base.py
+++ b/pulse2percept/models/tests/test_base.py
@@ -105,7 +105,7 @@ def test_BaseModel__is_built():
 
 
 def test_BaseModel_predict_percept():
-    img_stim = np.zeros((6, 10))
+    img_stim = np.zeros(60)
     model = ValidBaseModel(engine='serial', xystep=5, xrange=(-30, 30),
                            yrange=(-20, 20))
     # Model must be built first:
@@ -127,7 +127,7 @@ def test_BaseModel_predict_percept():
 
     # `predict` only accepts NumPy arrays
     for XX in [42, [3.3, 1.1], {'img': [[2]]}]:
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(ValueError):
             implants.ArgusII(stim=XX)
 
     # `img_stim` must have right size:
@@ -138,6 +138,6 @@ def test_BaseModel_predict_percept():
     # Single-pixel percept:
     model = ValidBaseModel(engine='serial', xrange=(0.45, 0.45), yrange=(0, 0))
     model.build()
-    percept = model.predict_percept(implants.ArgusII(stim=np.zeros((6, 10))))
+    percept = model.predict_percept(implants.ArgusII(stim=np.zeros(60)))
     npt.assert_equal(percept.shape, (1, 1))
     npt.assert_almost_equal(percept, 0)

--- a/pulse2percept/models/tests/test_scoreboard.py
+++ b/pulse2percept/models/tests/test_scoreboard.py
@@ -18,7 +18,7 @@ def test_ScoreboardModel():
     npt.assert_equal(model.rho, 987)
 
     # Zero in = zero out:
-    implant = implants.ArgusI(stim=np.zeros((4, 4)))
+    implant = implants.ArgusI(stim=np.zeros(16))
     npt.assert_almost_equal(model.predict_percept(implant), 0)
 
 
@@ -26,8 +26,8 @@ def test_ScoreboardModel_predict_percept():
     model = models.ScoreboardModel(xystep=1, rho=100, thresh_percept=0)
     model.build()
     # Single-electrode stim:
-    img_stim = np.zeros((6, 10))
-    img_stim[4, 7] = 1
+    img_stim = np.zeros(60)
+    img_stim[47] = 1
     percept = model.predict_percept(implants.ArgusII(stim=img_stim))
     # Single bright pixel, very small Gaussian kernel:
     npt.assert_equal(np.sum(percept > 0.9), 1)
@@ -40,5 +40,5 @@ def test_ScoreboardModel_predict_percept():
     # Full Argus II: 60 bright spots
     model = models.ScoreboardModel(engine='serial', xystep=1, rho=100)
     model.build()
-    percept = model.predict_percept(implants.ArgusII(stim=np.ones((6, 10))))
+    percept = model.predict_percept(implants.ArgusII(stim=np.ones(60)))
     npt.assert_equal(np.sum(np.isclose(percept, 0.9, rtol=0.1, atol=0.1)), 60)

--- a/pulse2percept/stimuli/__init__.py
+++ b/pulse2percept/stimuli/__init__.py
@@ -1,3 +1,4 @@
+from .base import Stimulus
 from .pulse_trains import (TimeSeries, MonophasicPulse, BiphasicPulse,
                            PulseTrain)
 
@@ -5,5 +6,6 @@ __all__ = [
     'BiphasicPulse',
     'MonophasicPulse',
     'PulseTrain',
+    'Stimulus',
     'TimeSeries'
 ]

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -2,7 +2,7 @@ import numpy as np
 np.set_printoptions(precision=2, threshold=5, edgeitems=2)
 from copy import deepcopy as cp
 from collections import OrderedDict as ODict
-from scipy import interpolate as spi
+from scipy.interpolate import interp1d
 
 from .pulse_trains import TimeSeries
 from ..utils import PrettyPrint
@@ -20,15 +20,6 @@ class Stimulus(PrettyPrint):
     A stimulus can be created from a variety of source types (see below),
     including lists and dictionaries. Depending on the source type, a stimulus
     might have a time component or not.
-
-    .. note::
-       A compression method is used to `sparsify` large and redundant data
-       sources such as `TimeSeries`.
-
-       This also means that all-zero source data and electrodes with all-zero
-       activation will be trimmed from the stimulus.
-
-       Set `sparsify=False` to deactivate this behavior.
 
     Parameters
     ----------
@@ -52,7 +43,7 @@ class Stimulus(PrettyPrint):
         * List or tuple: List elements will be assigned to electrodes in order.
         * Dictionary: Dictionary keys are used to address electrodes by name.
 
-    electrodes : int, string or list thereof
+    electrodes : int, string or list thereof; optional, default: None
         Optionally, you can provide your own electrode names. If none are
         given, electrode names will be extracted from the source type (e.g.,
         the keys from a dictionary). If a scalar or NumPy array is passed,
@@ -62,7 +53,7 @@ class Stimulus(PrettyPrint):
            The number of electrode names provided must match the number of
            electrodes extracted from the source type (i.e., N).
 
-    time : int, float or list thereof
+    time : int, float or list thereof; optional, default: None
         Optionally, you can provide the time points of the source data.
         If none are given, time steps will be numbered 0..M.
 
@@ -73,18 +64,25 @@ class Stimulus(PrettyPrint):
            Stimuli created from scalars or 1-D NumPy arrays will have no time
            componenet, in which case you cannot provide your own time points.
 
-    metadata : dict
+    metadata : dict, optional, default: None
         Additional stimulus metadata can be stored in a dictionary.
 
-    sparsify : bool
+    compress : bool, optional, default: False
         If True, will compress the source data in two ways:
         * Remove electrodes with all-zero activation.
         * Retain only the time points at which the stimulus changes.
+        For example, in a pulse train, only the signal edges are saved. This
+        drastically reduces the memory footprint of the stimulus.
 
-        .. note::
-           If set to False, most models will evaluate the percept at every time
-           step of the stimulus. For pulse trains, this is incredibly
-           inefficient.
+    interp_method : str or int, optional, default: 'linear'
+        For SciPy's `interp1` method, specifies the kind of interpolation as a
+        string ('linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic',
+        'previous', 'next') or as an integer specifying the order of the spline
+        interpolator to use.
+        Here, 'zero', 'slinear', 'quadratic' and 'cubic' refer to a spline
+        interpolation of zeroth, first, second or third order; 'previous' and
+        'next' simply return the previous or next value of the point.
+        By default, points outside the data range will be extrapolated.
 
     Examples
     --------
@@ -100,11 +98,20 @@ class Stimulus(PrettyPrint):
     >>> from pulse2percept.stimuli import Stimulus, PulseTrain
     >>> stim = Stimulus({'B9': PulseTrain(0.0001, freq=10, amp=40, dur=0.2)})
 
-    Stimulate ten electrodes with 0uA (make sure to deactivate sparsify,
-    otherwise your data container will be empty):
+    Compress an existing Stimulus:
+
+    >>> from pulse2percept.stimuli import Stimulus, PulseTrain
+    >>> stim = Stimulus({'B9': PulseTrain(0.0001, freq=10, amp=40, dur=0.5)})
+    >>> stim.shape
+    (1, 5000)
+    >>> stim.compress()
+    >>> stim.shape
+    (1, 40)
+
+    Stimulate ten electrodes with 0uA:
 
     >>> from pulse2percept.stimuli import Stimulus
-    >>> stim = Stimulus(np.zeros(10), sparsify=False)
+    >>> stim = Stimulus(np.zeros(10))
 
     Provide new electrode names for an existing Stimulus object:
 
@@ -112,71 +119,85 @@ class Stimulus(PrettyPrint):
     >>> old_stim = Stimulus([3, 5])
     >>> new_stim = Stimulus(old_stim, electrodes=['new0', 'new1'])
 
+    Interpolate the stimulus value at some point in time. Here, the stimulus
+    is a single-electrode ramp stimulus (stimulus value == point in time):
+
+    >>> from pulse2percept.stimuli import Stimulus
+    >>> stim = Stimulus(np.arange(10).reshape((1, -1)))
+    >>> stim.interp(time=3.45) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    Stimulus(compressed=False, data=[[...3.45]], electrodes=[0],
+             interp_method='linear', shape=(1, 1), time=[...3.45])
+
     """
 
     def __init__(self, source, electrodes=None, time=None, metadata=None,
-                 sparsify=True):
+                 compress=False, interp_method='linear'):
         # Extract the data and coordinates (electrodes, time) from the source:
-        data, electrodes, time = self._factory(source, electrodes, time)
-        if sparsify:
-            # Sparsify the data. For example, in a pulse train, only the signal
-            # edges are saved. This drastically reduces the memory footprint of
-            # the stimulus:
-            data, electrodes, time = self.sparsify(data, electrodes, time)
+        data, electrodes, time, compress = self._factory(source, electrodes,
+                                                         time, compress)
         # Save all attributes:
         self.data = data
         self.shape = data.shape
         self.electrodes = electrodes
         self.time = time
         self.metadata = metadata
+        self.compressed = False
+        # Compress the data if necessary (will set compressed to True):
+        if compress:
+            self.compress()
+        # Set up the interpolator:
+        self.interp_method = interp_method
+        self._set_interp()
 
     def get_params(self):
+        """Return a dictionary of class attributes"""
         return {'data': self.data, 'electrodes': self.electrodes,
-                'time': self.time, 'shape': self.shape}
+                'time': self.time, 'shape': self.shape,
+                'compressed': self.compressed,
+                'interp_method': self.interp_method}
 
     def _from_source(self, source):
         """Extract the data container and time information from source data
-
         This private method converts input data from allowable source types
         into a 2D NumPy array, where the first dimension denotes electrodes
         and the second dimension denotes points in time.
-
         Some stimuli don't have a time component (such as a stimulus created
         from a scalar or 1D NumPy array. In this case, times=None.
         """
         if np.isscalar(source) and not isinstance(source, str):
             # Scalar: 1 electrode, no time component
             time = None
-            data = np.array([source]).reshape((1, -1))
+            data = np.array([source], dtype=float).reshape((1, -1))
         elif isinstance(source, (list, tuple)):
             # List or touple with N elements: 1 electrode, N time points
             time = np.arange(len(source))
-            data = np.array(source).reshape((1, -1))
+            data = np.array(source, dtype=float).reshape((1, -1))
         elif isinstance(source, np.ndarray):
             if source.ndim > 1:
                 raise ValueError("Cannot create Stimulus object from a %d-D "
                                  "NumPy array. Must be 1-D." % source.ndim)
             # 1D NumPy array with N elements: 1 electrode, N time points
             time = np.arange(len(source))
-            data = source.reshape((1, -1))
+            data = source.astype(float).reshape((1, -1))
         elif isinstance(source, TimeSeries):
             # TimeSeries with NxM time points: N electrodes, M time points
             time = np.arange(source.shape[-1]) * source.tsample
-            data = source.data.reshape((-1, len(time)))
+            data = source.data.astype(float).reshape((-1, len(time)))
         else:
             raise TypeError("Cannot create Stimulus object from %s. Choose "
                             "from: scalar, tuple, list, NumPy array, or "
                             "TimeSeries." % type(source))
         return time, data
 
-    def _factory(self, source, electrodes, time):
+    def _factory(self, source, electrodes, time, compress):
         if isinstance(source, self.__class__):
             # Stimulus: We're done. This might happen in ProsthesisSystem if
             # the user builds the stimulus themselves. It can also be used to
             # overwrite the time axis or provide new electrode names.
             _data = source.data
-            _time = source.time 
+            _time = source.time
             _electrodes = source.electrodes
+            _compress = source.compressed
         else:
             # Input is either be a valid source type (see `self._from_source`)
             # or a collection thereof. Thus treat everything as a collection,
@@ -190,6 +211,7 @@ class Stimulus(PrettyPrint):
             _time = []
             _electrodes = []
             _data = []
+            _compress = compress
             for e, s in iterator:
                 # Extract times and data from source:
                 t, d = self._from_source(s)
@@ -210,11 +232,11 @@ class Stimulus(PrettyPrint):
                                      "but electrode %s has t=%s and electrode %s "
                                      "has t=%s." % (_electrodes[0], _time[0],
                                                     _electrodes[e], t))
-                    break
-            _time = _time[0]
+            _time = _time[0] if _time else None
+            # _time = _time[0]
             # Now make `data` a 2-D NumPy array, with `electrodes` as rows and
             # `times` as columns (except sometimes `times` is None).
-            _data = np.vstack(_data)
+            _data = np.vstack(_data) if _data else np.array([])
         # User can overwrite the names of the electrodes:
         if electrodes is not None:
             electrodes = np.array(electrodes).flatten()
@@ -237,11 +259,19 @@ class Stimulus(PrettyPrint):
                                  "match the number of time steps in the data "
                                  "(%d)." % (len(time), _data.shape[1]))
             _time = time
-        return _data, _electrodes, _time
+        return _data, _electrodes, _time, _compress
 
-    @staticmethod
-    def sparsify(data, electrodes, time):
-        """Compress the source data"""
+    def compress(self):
+        """Compress the source data
+
+        Returns
+        -------
+        compressed : Stimulus
+
+        """
+        data = self.data
+        electrodes = self.electrodes
+        time = self.time
         # Remove rows (electrodes) with all zeros:
         keep_el = [not np.allclose(row, 0) for row in data]
         data = data[keep_el]
@@ -275,4 +305,161 @@ class Stimulus(PrettyPrint):
             # now we need to vertically stack them and transpose:
             data = np.vstack(signal).T
             time = np.array(ticks)
-        return data, electrodes, time
+        self.data = data
+        self.shape = data.shape
+        self.electrodes = electrodes
+        self.time = time
+        self.compressed = True
+
+    def _need_interp(self):
+        """Returns True if new interpolator needs to be set up"""
+        if self.time is None:
+            return False
+        if len(self.time) <= 1:
+            return False
+        return True
+
+    def _set_interp(self):
+        """Set up the interpolator"""
+        self._interp = None
+        if self._need_interp():
+            self._interp = [interp1d(self.time, row, kind=self.interp_method,
+                                     assume_sorted=True, bounds_error=False,
+                                     fill_value='extrapolate')
+                            for row in self.data]
+
+    def interp(self, time=None):
+        """Interpolate along the time axis
+
+        SciPy's `interp1d <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html>`_ method is used to interpolate stimulus values along
+        the time axis. An interpolation method can be set in the Stimulus
+        constructor.
+
+        Parameters
+        ----------
+        time : int, float or list thereof
+            The time point(s) at which to interpolate the stimulus
+
+        Returns
+        -------
+        interpolated: Stimulus
+            New Stimulus object with new time coordinates
+
+        Examples
+        --------
+        Interpolate the stimulus value at some point in time. Here, the
+        stimulus is a single-electrode ramp stimulus (stimulus value == point
+        in time):
+
+        >>> from pulse2percept.stimuli import Stimulus
+        >>> stim = Stimulus(np.arange(10).reshape((1, -1)))
+        >>> stim.interp(time=3.45) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+        Stimulus(compressed=False, data=[[...3.45]], electrodes=[0],
+                 interp_method='linear', shape=(1, 1), time=[...3.45])
+
+        Use the 'nearest' interpolation method instead
+        (see `scipy.interpolate.interp1d <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html>`_):
+
+        >>> from pulse2percept.stimuli import Stimulus
+        >>> stim = Stimulus(np.arange(10).reshape((1, -1)),
+        ...                 interp_method='nearest')
+        >>> stim.interp(time=3.45) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+        Stimulus(compressed=False, data=[[...3.]], electrodes=[0],
+                 interp_method='linear', shape=(1, 1), time=[...3.45])
+
+        Extrapolate to a time point outside the provided data range:
+
+        >>> from pulse2percept.stimuli import Stimulus
+        >>> stim = Stimulus(np.arange(10).reshape((1, -1)))
+        >>> stim.interp(time=123.45) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+        Stimulus(compressed=False, data=[[...123.45]], electrodes=[0],
+                 interp_method='linear', shape=(1, 1), time=[...123.45])
+
+        """
+        if not self._need_interp():
+            # This includes the special case of a single time point (where
+            # `interp1d` would not work):
+            return Stimulus(self.data[:, 0], electrodes=self.electrodes,
+                            time=None, compress=self.compressed)
+
+        # Should work with scalars and lists:
+        time = np.array([time]).flatten()
+        data = np.array([[self._interp[e](t) for t in time]
+                         for e, _ in enumerate(self.electrodes)])
+        return Stimulus(data, electrodes=self.electrodes, time=time,
+                        compress=self.compressed)
+
+    def __eq__(self, other):
+        """Returns True if two Stimulus objects are identical
+
+        Two Stimulus objects are considered identical if they have the same
+        electrode names, time steps, and data points.
+
+        Parameters
+        ----------
+        other : any
+            Another object or variable to which the current object should be
+            compared.
+
+        Examples
+        --------
+        >>> from pulse2percept.stimuli import Stimulus
+        >>> stim1 = Stimulus(np.ones(3))
+        >>> stim2 = Stimulus(np.zeros(5))
+        >>> stim1 == stim2
+        False
+
+        Compare a Stimulus with something else entirely:
+
+        >>> from pulse2percept.stimuli import Stimulus
+        >>> stim1 = Stimulus(np.ones(3))
+        >>> stim1 == 1
+        False
+
+        """
+        if not isinstance(other, Stimulus):
+            return False
+        if self.time is None:
+            if other.time is not None:
+                return False
+        else:
+            if other.time is None:
+                return False
+            if len(self.time) != len(other.time):
+                return False
+            if not np.allclose(self.time, other.time):
+                return False
+        if len(self.electrodes) != len(other.electrodes):
+            return False
+        if not np.all(self.electrodes == other.electrodes):
+            return False
+        if self.shape != other.shape:
+            return False
+        if not np.allclose(self.data, other.data):
+            return False
+        return True
+
+    def __ne__(self, other):
+        """Returns True if two Stimulus objects are different
+
+        Two Stimulus objects are considered different if they store different
+        electrode names, time steps, or data points.
+
+        Parameters
+        ----------
+        other : any
+            Another object or variable to which the current object should be
+            compared.
+
+        Examples
+        --------
+        Compare two Stimulus objects:
+
+        >>> from pulse2percept.stimuli import Stimulus
+        >>> stim1 = Stimulus(np.ones(3))
+        >>> stim2 = Stimulus(np.zeros(5))
+        >>> stim1 != stim2
+        True
+
+        """
+        return not self.__eq__(other)

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -9,80 +9,127 @@ from ..utils import PrettyPrint
 
 
 class Stimulus(PrettyPrint):
+    """Stimulus
 
-    def __init__(self, source, electrode=None, time=None, metadata=None):
-        # Input is either be a valid source type (see ``self._from_source``) or
-        # a collection thereof. Thus treat everything as a collection, and
-        # iterate:
-        if isinstance(source, dict):
-            iterator = source.items()
-        elif isinstance(source, (list, tuple, np.ndarray)):
-            iterator = enumerate(source)
-        else:
-            iterator = enumerate([source])
-        _times = []
-        _electrodes = []
-        data = []
-        for e, s in iterator:
-            # Extract times and data from source:
-            t, d = self._from_source(s)
-            _times.append(t)
-            _electrodes.append(e)
-            data.append(d)
-        # Now make `data` a 2-D NumPy array, with `electrodes` as rows and
-        # `times` as columns (except sometimes `times` is None).
-        data = np.vstack(data)
-        # User can overwrite the names of the electrodes:
-        if electrode is not None:
-            electrode = np.array(electrode).flatten()
-            if len(electrode) != data.shape[0]:
-                raise ValueError("Number of electrodes provided (%d) does not "
-                                 "match the number of electrodes in the data "
-                                 "(%d)." % (len(electrode), data.shape[0]))
-            _electrodes = electrode
-        else:
-            _electrodes = np.array(_electrodes)
-        # All elements of `times` must be the same, but they can either be None
-        # or a NumPy array, so comparing with == will fail. Therefore, convert
-        # all elements to NumPy float arrays, which will convert None to NaN.
-        # Then you can compare two entries with np.allclose, making sure the
-        # `equal_nan` option is set to True so that two NaNs are considered
-        # equal:
-        for e, t in enumerate(_times):
-            if not np.allclose(np.array(t, dtype=float),
-                               np.array(_times[0], dtype=float),
-                               equal_nan=True):
-                raise ValueError("All stimuli must have the same time axis, "
-                                 "but electrode %s has t=%s and electrode %s "
-                                 "has t=%s." % (_electrodes[0], _times[0],
-                                                _electrodes[e], t))
-                break
-        _times = _times[0]
-        # User can overwrite time:
-        if time is not None:
-            if _times is None:
-                raise ValueError("Cannot set times=%s, because stimulus does "
-                                 "not have a time component." % time)
-            time = np.array(time).flatten()
-            if len(time) != data.shape[1]:
-                raise ValueError("Number of time steps provided (%d) does not "
-                                 "match the number of time steps in the data "
-                                 "(%d)." % (len(time), data.shape[1]))
-            _times = time
+    A stimulus is comprised of a labeled 2-D NumPy array that contains the
+    data, where the rows denoted electrodes and the columns denote points in
+    time.
 
-        # Last step is to sparsify the data. For example, in a pulse train,
-        # only the signal edges are saved. This drastically reduces the memory
-        # footprint of the stimulus:
-        data, _electrodes, _times = self.sparsify(data, _electrodes, _times)
+    A stimulus can be created from a variety of source types (see below),
+    including lists and dictionaries. Depending on the source type, a stimulus
+    might have a time component or not.
 
+    .. note::
+       A compression method is used to `sparsify` large and redundant data
+       sources such as `TimeSeries`.
+
+       This also means that all-zero source data and electrodes with all-zero
+       activation will be trimmed from the stimulus.
+
+       Set `sparsify=False` to deactivate this behavior.
+
+    Parameters
+    ----------
+    source : source type
+        A valid source type is one of the following:
+
+        * Scalar value: interpreted as the current amplitude delivered to a
+          single electrode (no time component).
+        * NumPy array:
+           * Nx1 array: interpreted as N current amplitudes delivered to N
+             electrodes (no time component).
+           * NxM array: interpreted as N electrodes each receiving M current
+             amplitudes in time.
+        * `TimeSeries`: interpreted as the stimulus in time for a single
+          electrode (e.g., `BiphasicPulse`, `PulseTrain`).
+
+        In addition, you can also pass a collection of source types.
+        Each element must be a valid source type for a single electrode (e.g.,
+        scalar, 1-D array, TimeSeries).
+
+        * List or tuple: List elements will be assigned to electrodes in order.
+        * Dictionary: Dictionary keys are used to address electrodes by name.
+
+    electrodes : int, string or list thereof
+        Optionally, you can provide your own electrode names. If none are
+        given, electrode names will be extracted from the source type (e.g.,
+        the keys from a dictionary). If a scalar or NumPy array is passed,
+        electrode names will be numbered 0..N.
+
+        .. note::
+           The number of electrode names provided must match the number of
+           electrodes extracted from the source type (i.e., N).
+
+    time : int, float or list thereof
+        Optionally, you can provide the time points of the source data.
+        If none are given, time steps will be numbered 0..M.
+
+        .. note::
+           The number of time points provided must match the number of time
+           points extracted from the source type (i.e., M).
+
+           Stimuli created from scalars or 1-D NumPy arrays will have no time
+           componenet, in which case you cannot provide your own time points.
+
+    metadata : dict
+        Additional stimulus metadata can be stored in a dictionary.
+
+    sparsify : bool
+        If True, will compress the source data in two ways:
+        * Remove electrodes with all-zero activation.
+        * Retain only the time points at which the stimulus changes.
+
+        .. note::
+           If set to False, most models will evaluate the percept at every time
+           step of the stimulus. For pulse trains, this is incredibly
+           inefficient.
+
+    Examples
+    --------
+    Stimulate a single electrode with -13uA:
+
+    >>> from pulse2percept.stimuli import Stimulus
+    >>> stim = Stimulus(-13)
+
+    Stimulate Electrode 'B9' with a 10Hz cathodic-first pulse train lasting
+    0.2 seconds, with 0.45ms pulse duration, 40uA current amplitude, and the
+    time series resolved at 0.1ms resolution:
+
+    >>> from pulse2percept.stimuli import Stimulus, PulseTrain
+    >>> stim = Stimulus({'B9': PulseTrain(0.0001, freq=10, amp=40, dur=0.2)})
+
+    Stimulate ten electrodes with 0uA (make sure to deactivate sparsify,
+    otherwise your data container will be empty):
+
+    >>> from pulse2percept.stimuli import Stimulus
+    >>> stim = Stimulus(np.zeros(10), sparsify=False)
+
+    Provide new electrode names for an existing Stimulus object:
+
+    >>> from pulse2percept.stimuli import Stimulus
+    >>> old_stim = Stimulus([3, 5])
+    >>> new_stim = Stimulus(old_stim, electrodes=['new0', 'new1'])
+
+    """
+
+    def __init__(self, source, electrodes=None, time=None, metadata=None,
+                 sparsify=True):
+        # Extract the data and coordinates (electrodes, time) from the source:
+        data, electrodes, time = self._factory(source, electrodes, time)
+        if sparsify:
+            # Sparsify the data. For example, in a pulse train, only the signal
+            # edges are saved. This drastically reduces the memory footprint of
+            # the stimulus:
+            data, electrodes, time = self.sparsify(data, electrodes, time)
+        # Save all attributes:
         self.data = data
         self.shape = data.shape
-        self.electrode = _electrodes
-        self.time = _times
+        self.electrodes = electrodes
+        self.time = time
         self.metadata = metadata
 
     def get_params(self):
-        return {'data': self.data, 'electrode': self.electrode,
+        return {'data': self.data, 'electrodes': self.electrodes,
                 'time': self.time, 'shape': self.shape}
 
     def _from_source(self, source):
@@ -95,15 +142,21 @@ class Stimulus(PrettyPrint):
         Some stimuli don't have a time component (such as a stimulus created
         from a scalar or 1D NumPy array. In this case, times=None.
         """
-        if np.isscalar(source) and not isinstance(source, str):
+        if isinstance(source, self.__class__):
+            # Stimulus: We're done. This might happen in ProsthesisSystem if
+            # the user builds the stimulus themselves. It can also be used to
+            # overwrite the time axis or provide new electrode names.
+            time = source.time
+            data = source.data
+        elif np.isscalar(source) and not isinstance(source, str):
             print('scalar')
             # Scalar: 1 electrode, no time component
-            times = None
+            time = None
             data = np.array([source]).reshape((1, -1))
         elif isinstance(source, (list, tuple)):
             print("list/tuple")
             # List or touple with N elements: 1 electrode, N time points
-            times = np.arange(len(source))
+            time = np.arange(len(source))
             data = np.array(source).reshape((1, -1))
         elif isinstance(source, np.ndarray):
             print("ndarray", source, source.ndim)
@@ -111,62 +164,114 @@ class Stimulus(PrettyPrint):
                 raise ValueError("Cannot create Stimulus object from a %d-D "
                                  "NumPy array. Must be 1-D." % source.ndim)
             # 1D NumPy array with N elements: 1 electrode, N time points
-            times = np.arange(len(source))
+            time = np.arange(len(source))
             data = source.reshape((1, -1))
         elif isinstance(source, TimeSeries):
             print('timeseries')
             # TimeSeries with NxM time points: N electrodes, M time points
-            times = np.arange(source.shape[-1]) * source.tsample
-            data = source.data.reshape((-1, len(times)))
+            time = np.arange(source.shape[-1]) * source.tsample
+            data = source.data.reshape((-1, len(time)))
         else:
             raise TypeError("Cannot create Stimulus object from %s. Choose "
                             "from: scalar, tuple, list, NumPy array, or "
                             "TimeSeries." % type(source))
-        return times, data
+        return time, data
+
+    def _factory(self, source, electrodes, time):
+        # Input is either be a valid source type (see ``self._from_source``) or
+        # a collection thereof. Thus treat everything as a collection, and
+        # iterate:
+        if isinstance(source, dict):
+            iterator = source.items()
+        elif isinstance(source, (list, tuple, np.ndarray)):
+            iterator = enumerate(source)
+        else:
+            iterator = enumerate([source])
+        _time = []
+        _electrodes = []
+        _data = []
+        for e, s in iterator:
+            # Extract times and data from source:
+            t, d = self._from_source(s)
+            _time.append(t)
+            _electrodes.append(e)
+            _data.append(d)
+        # Now make `data` a 2-D NumPy array, with `electrodes` as rows and
+        # `times` as columns (except sometimes `times` is None).
+        _data = np.vstack(_data)
+        # User can overwrite the names of the electrodes:
+        if electrodes is not None:
+            electrodes = np.array(electrodes).flatten()
+            if len(electrodes) != _data.shape[0]:
+                raise ValueError("Number of electrodes provided (%d) does not "
+                                 "match the number of electrodes in the data "
+                                 "(%d)." % (len(electrodes), _data.shape[0]))
+            _electrodes = electrodes
+        else:
+            _electrodes = np.array(_electrodes)
+        # All elements of `times` must be the same, but they can either be None
+        # or a NumPy array, so comparing with == will fail. Therefore, convert
+        # all elements to NumPy float arrays, which will convert None to NaN.
+        # Then you can compare two entries with np.allclose, making sure the
+        # `equal_nan` option is set to True so that two NaNs are considered
+        # equal:
+        for e, t in enumerate(_time):
+            if not np.allclose(np.array(t, dtype=float),
+                               np.array(_time[0], dtype=float),
+                               equal_nan=True):
+                raise ValueError("All stimuli must have the same time axis, "
+                                 "but electrode %s has t=%s and electrode %s "
+                                 "has t=%s." % (_electrodes[0], _time[0],
+                                                _electrodes[e], t))
+                break
+        _time = _time[0]
+        # User can overwrite time:
+        if time is not None:
+            if _time is None:
+                raise ValueError("Cannot set times=%s, because stimulus does "
+                                 "not have a time component." % time)
+            time = np.array(time).flatten()
+            if len(time) != _data.shape[1]:
+                raise ValueError("Number of time steps provided (%d) does not "
+                                 "match the number of time steps in the data "
+                                 "(%d)." % (len(time), _data.shape[1]))
+            _time = time
+        return _data, _electrodes, _time
 
     @staticmethod
-    def sparsify(data, electrodes, times):
+    def sparsify(data, electrodes, time):
+        """Compress the source data"""
         # Remove rows (electrodes) with all zeros:
         keep_el = [not np.allclose(row, 0) for row in data]
         data = data[keep_el]
         electrodes = electrodes[keep_el]
 
-        if times is not None:
+        if time is not None:
             # In time, we can't just remove empty columns. We need to walk
             # through each column and save all the "state transitions" along
             # with the points in time when they happened. For example, a
             # digital signal:
-            # data = [0 0 1 1 1 1 0 0 0 1], times = [0 1 2 3 4 5 6 7 8 9]
+            # data = [0 0 1 1 1 1 0 0 0 1], time = [0 1 2 3 4 5 6 7 8 9]
             # becomes
-            # data = [0 0 1 1 0 0 1],       times = [0 1 2 5 6 8 9].
+            # data = [0 0 1 1 0 0 1],       time = [0 1 2 5 6 8 9].
             # You always need the first and last element. You also need the
             # high and low value (along with the time stamps) for every signal
             # edge.
-            time = []  # sparsified time stamps
+            ticks = []  # sparsified time stamps
             signal = []  # sparsified signal values
             for t in range(data.shape[-1]):
                 if t == 0 or t == data.shape[-1] - 1:
                     # Always need the first and last element:
-                    time.append(times[t])
+                    ticks.append(time[t])
                     signal.append(data[:, t])
                 else:
                     if not np.allclose(data[:, t], data[:, t - 1]):
-                        time.append(times[t - 1])
+                        ticks.append(time[t - 1])
                         signal.append(data[:, t - 1])
-                        time.append(times[t])
+                        ticks.append(time[t])
                         signal.append(data[:, t])
             # NumPy made the slices row vectors instead of column vectors, so
             # now we need to vertically stack them and transpose:
             data = np.vstack(signal).T
-            times = np.array(time)
-        return data, electrodes, times
-
-
-#     def sel(self, electrode=None, t=None):
-#         pass
-
-#     def interp(self, electrode=None, t=None, fill_values='extrapolate'):
-#         pass
-
-#     def plot(self, electrode=None, t=None):
-#         pass
+            time = np.array(ticks)
+        return data, electrodes, time

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -1,0 +1,172 @@
+import numpy as np
+np.set_printoptions(precision=2, threshold=5, edgeitems=2)
+from copy import deepcopy as cp
+from collections import OrderedDict as ODict
+from scipy import interpolate as spi
+
+from .pulse_trains import TimeSeries
+from ..utils import PrettyPrint
+
+
+class Stimulus(PrettyPrint):
+
+    def __init__(self, source, electrode=None, time=None, metadata=None):
+        # Input is either be a valid source type (see ``self._from_source``) or
+        # a collection thereof. Thus treat everything as a collection, and
+        # iterate:
+        if isinstance(source, dict):
+            iterator = source.items()
+        elif isinstance(source, (list, tuple, np.ndarray)):
+            iterator = enumerate(source)
+        else:
+            iterator = enumerate([source])
+        _times = []
+        _electrodes = []
+        data = []
+        for e, s in iterator:
+            # Extract times and data from source:
+            t, d = self._from_source(s)
+            _times.append(t)
+            _electrodes.append(e)
+            data.append(d)
+        # Now make `data` a 2-D NumPy array, with `electrodes` as rows and
+        # `times` as columns (except sometimes `times` is None).
+        data = np.vstack(data)
+        # User can overwrite the names of the electrodes:
+        if electrode is not None:
+            electrode = np.array(electrode).flatten()
+            if len(electrode) != data.shape[0]:
+                raise ValueError("Number of electrodes provided (%d) does not "
+                                 "match the number of electrodes in the data "
+                                 "(%d)." % (len(electrode), data.shape[0]))
+            _electrodes = electrode
+        else:
+            _electrodes = np.array(_electrodes)
+        # All elements of `times` must be the same, but they can either be None
+        # or a NumPy array, so comparing with == will fail. Therefore, convert
+        # all elements to NumPy float arrays, which will convert None to NaN.
+        # Then you can compare two entries with np.allclose, making sure the
+        # `equal_nan` option is set to True so that two NaNs are considered
+        # equal:
+        for e, t in enumerate(_times):
+            if not np.allclose(np.array(t, dtype=float),
+                               np.array(_times[0], dtype=float),
+                               equal_nan=True):
+                raise ValueError("All stimuli must have the same time axis, "
+                                 "but electrode %s has t=%s and electrode %s "
+                                 "has t=%s." % (_electrodes[0], _times[0],
+                                                _electrodes[e], t))
+                break
+        _times = _times[0]
+        # User can overwrite time:
+        if time is not None:
+            if _times is None:
+                raise ValueError("Cannot set times=%s, because stimulus does "
+                                 "not have a time component." % time)
+            time = np.array(time).flatten()
+            if len(time) != data.shape[1]:
+                raise ValueError("Number of time steps provided (%d) does not "
+                                 "match the number of time steps in the data "
+                                 "(%d)." % (len(time), data.shape[1]))
+            _times = time
+
+        # Last step is to sparsify the data. For example, in a pulse train,
+        # only the signal edges are saved. This drastically reduces the memory
+        # footprint of the stimulus:
+        data, _electrodes, _times = self.sparsify(data, _electrodes, _times)
+
+        self.data = data
+        self.shape = data.shape
+        self.electrode = _electrodes
+        self.time = _times
+        self.metadata = metadata
+
+    def get_params(self):
+        return {'data': self.data, 'electrode': self.electrode,
+                'time': self.time, 'shape': self.shape}
+
+    def _from_source(self, source):
+        """Extract the data container and time information from source data
+
+        This private method converts input data from allowable source types
+        into a 2D NumPy array, where the first dimension denotes electrodes
+        and the second dimension denotes points in time.
+
+        Some stimuli don't have a time component (such as a stimulus created
+        from a scalar or 1D NumPy array. In this case, times=None.
+        """
+        if np.isscalar(source) and not isinstance(source, str):
+            print('scalar')
+            # Scalar: 1 electrode, no time component
+            times = None
+            data = np.array([source]).reshape((1, -1))
+        elif isinstance(source, (list, tuple)):
+            print("list/tuple")
+            # List or touple with N elements: 1 electrode, N time points
+            times = np.arange(len(source))
+            data = np.array(source).reshape((1, -1))
+        elif isinstance(source, np.ndarray):
+            print("ndarray", source, source.ndim)
+            if source.ndim > 1:
+                raise ValueError("Cannot create Stimulus object from a %d-D "
+                                 "NumPy array. Must be 1-D." % source.ndim)
+            # 1D NumPy array with N elements: 1 electrode, N time points
+            times = np.arange(len(source))
+            data = source.reshape((1, -1))
+        elif isinstance(source, TimeSeries):
+            print('timeseries')
+            # TimeSeries with NxM time points: N electrodes, M time points
+            times = np.arange(source.shape[-1]) * source.tsample
+            data = source.data.reshape((-1, len(times)))
+        else:
+            raise TypeError("Cannot create Stimulus object from %s. Choose "
+                            "from: scalar, tuple, list, NumPy array, or "
+                            "TimeSeries." % type(source))
+        return times, data
+
+    @staticmethod
+    def sparsify(data, electrodes, times):
+        # Remove rows (electrodes) with all zeros:
+        keep_el = [not np.allclose(row, 0) for row in data]
+        data = data[keep_el]
+        electrodes = electrodes[keep_el]
+
+        if times is not None:
+            # In time, we can't just remove empty columns. We need to walk
+            # through each column and save all the "state transitions" along
+            # with the points in time when they happened. For example, a
+            # digital signal:
+            # data = [0 0 1 1 1 1 0 0 0 1], times = [0 1 2 3 4 5 6 7 8 9]
+            # becomes
+            # data = [0 0 1 1 0 0 1],       times = [0 1 2 5 6 8 9].
+            # You always need the first and last element. You also need the
+            # high and low value (along with the time stamps) for every signal
+            # edge.
+            time = []  # sparsified time stamps
+            signal = []  # sparsified signal values
+            for t in range(data.shape[-1]):
+                if t == 0 or t == data.shape[-1] - 1:
+                    # Always need the first and last element:
+                    time.append(times[t])
+                    signal.append(data[:, t])
+                else:
+                    if not np.allclose(data[:, t], data[:, t - 1]):
+                        time.append(times[t - 1])
+                        signal.append(data[:, t - 1])
+                        time.append(times[t])
+                        signal.append(data[:, t])
+            # NumPy made the slices row vectors instead of column vectors, so
+            # now we need to vertically stack them and transpose:
+            data = np.vstack(signal).T
+            times = np.array(time)
+        return data, electrodes, times
+
+
+#     def sel(self, electrode=None, t=None):
+#         pass
+
+#     def interp(self, electrode=None, t=None, fill_values='extrapolate'):
+#         pass
+
+#     def plot(self, electrode=None, t=None):
+#         pass

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -1,0 +1,159 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+from collections import OrderedDict as ODict
+
+from pulse2percept.stimuli import Stimulus, PulseTrain
+
+
+def test_Stimulus():
+    # One electrode:
+    stim = Stimulus(3)
+    npt.assert_equal(stim.shape, (1, 1))
+    npt.assert_equal(stim.electrode, [0])
+    npt.assert_equal(stim.time, None)
+    # One electrode with a name:
+    stim = Stimulus(3, electrode='AA001')
+    npt.assert_equal(stim.shape, (1, 1))
+    npt.assert_equal(stim.electrode, ['AA001'])
+    npt.assert_equal(stim.time, None)
+    # Ten electrodes, one will be trimmed:
+    stim = Stimulus(np.arange(10))
+    npt.assert_equal(stim.shape, (9, 1))
+    npt.assert_equal(stim.electrode, np.arange(1, 10))
+    npt.assert_equal(stim.time, None)
+    # Electrodes + specific time, time will be trimmed:
+    stim = Stimulus(np.ones((4, 3)), time=[-3, -2, -1])
+    npt.assert_equal(stim.shape, (4, 2))
+    npt.assert_equal(stim.time, [-3, -1])
+    # Specific names:
+    stim = Stimulus({'A1': 3, 'C5': 8})
+    npt.assert_equal(stim.shape, (2, 1))
+    npt.assert_equal(np.sort(stim.electrode), np.sort(['A1', 'C5']))
+    npt.assert_equal(stim.time, None)
+    # Specific names, renamed:
+    stim = Stimulus({'A1': 3, 'C5': 8}, electrode=['B7', 'B8'])
+    npt.assert_equal(stim.shape, (2, 1))
+    npt.assert_equal(np.sort(stim.electrode), np.sort(['B7', 'B8']))
+    npt.assert_equal(stim.time, None)
+    # Electrodes x time, time will be trimmed:
+    stim = Stimulus(np.ones((6, 100)))
+    npt.assert_equal(stim.shape, (6, 2))
+    # Single electrode in time:
+    stim = Stimulus(PulseTrain(0.01 / 1000, dur=0.005))
+    # Specific electrode in time:
+    stim = Stimulus({'C3': PulseTrain(0.01 / 1000, dur=0.004)})
+    # Multiple specific electrodes in time:
+    stim = Stimulus({'C3': PulseTrain(0.01 / 1000, dur=0.004),
+                     'F4': PulseTrain(0.01 / 1000, delay=0.0001, dur=0.004)})
+    # Saves metadata:
+    metadata = {'a': 0, 'b': 1}
+    stim = Stimulus(3, metadata=metadata)
+    npt.assert_equal(stim.metadata, metadata)
+
+    # Not allowed:
+    with pytest.raises(ValueError):
+        # Multiple electrodes in time, different time stamps:
+        stim = Stimulus([PulseTrain(0.01 / 1000, dur=0.004),
+                         PulseTrain(0.005 / 1000, dur=0.002)])
+    with pytest.raises(ValueError):
+        # First one doesn't have time:
+        stim = Stimulus({'A2': 1, 'C3': PulseTrain(0.01 / 1000, dur=0.004)})
+    with pytest.raises(ValueError):
+        # Invalid source type:
+        stim = Stimulus(np.ones((3, 4, 5, 6)))
+    with pytest.raises(TypeError):
+        # Invalid source type:
+        stim = Stimulus("invalid")
+    with pytest.raises(ValueError):
+        # Wrong number of electrodes:
+        stim = Stimulus([3, 4], electrode='A1')
+    with pytest.raises(ValueError):
+        # Wrong number of time points:
+        stim = Stimulus(np.ones((3, 5)), time=[0, 1, 2])
+    with pytest.raises(ValueError):
+        # Can't force time:
+        stim = Stimulus(3, time=[0.4])
+
+
+@pytest.mark.parametrize('tsample', (5e-6, 1e-7))
+def test_Stimulus_sparsify(tsample):
+    # Single pulse train:
+    pdur = 0.00045
+    pt = PulseTrain(tsample, pulse_dur=pdur, dur=0.005)
+    idata = pt.data.reshape((1, -1))
+    ielec = np.array([0])
+    itime = np.arange(idata.shape[-1]) * pt.tsample
+    # Sparsify should compress the data. The original `tsample` shouldn't
+    # matter as long as the resolution is fine enough to capture all of the
+    # pulse train:
+    odata, oelec, otime = Stimulus.sparsify(idata, ielec, itime)
+    npt.assert_equal(odata.shape, (1, 8))
+    # Electrodes are unchanged:
+    npt.assert_equal(ielec, oelec)
+    # First and last time step are always preserved:
+    npt.assert_almost_equal(itime[0], otime[0])
+    npt.assert_almost_equal(itime[-1], otime[-1])
+    # The first rising edge happens at t=`pdur`:
+    npt.assert_almost_equal(otime[1], pdur - tsample)
+    npt.assert_almost_equal(odata[0, 1], -20)
+    npt.assert_almost_equal(otime[2], pdur)
+    npt.assert_almost_equal(odata[0, 2], 0)
+
+    # Two pulse trains with slight delay/offset, and a third that's all 0:
+    delay = 0.0001
+    pt = PulseTrain(tsample, delay=0, dur=0.005)
+    pt2 = PulseTrain(tsample, delay=delay, dur=0.005)
+    pt3 = PulseTrain(tsample, amp=0, dur=0.005)
+    idata = np.vstack((pt.data, pt2.data, pt3.data))
+    ielec = np.array([0, 1, 2])
+    itime = np.arange(idata.shape[-1]) * pt.tsample
+    # Sparsify should compress the data. The original `tsample` shouldn't
+    # matter as long as the resolution is fine enough to capture all of the
+    # pulse train:
+    odata, oelec, otime = Stimulus.sparsify(idata, ielec, itime)
+    npt.assert_equal(odata.shape, (2, 16))
+    # Zero electrodes should be deselected:
+    npt.assert_equal(oelec, np.array([0, 1]))
+    # First and last time step are always preserved:
+    npt.assert_almost_equal(itime[0], otime[0])
+    npt.assert_almost_equal(itime[-1], otime[-1])
+    # The first rising edge happens at t=`delay`:
+    npt.assert_almost_equal(otime[1], delay - tsample)
+    npt.assert_almost_equal(odata[0, 1], -20)
+    npt.assert_almost_equal(odata[1, 1], 0)
+    npt.assert_almost_equal(otime[2], delay)
+    npt.assert_almost_equal(odata[0, 2], -20)
+    npt.assert_almost_equal(odata[1, 2], -20)
+
+    # Repeated calls to sparsify won't change the result:
+    idata = odata
+    ielec = oelec
+    itime = otime
+    odata, oelec, otime = Stimulus.sparsify(idata, ielec, itime)
+    npt.assert_equal(idata, odata)
+    npt.assert_equal(ielec, oelec)
+    npt.assert_equal(itime, otime)
+
+
+# def test_Stimulus__from_ndarray():
+#     # From NumPy array:
+#     shape = (2, 4)
+#     stim = Stimulus(np.ones(shape))
+#     npt.assert_equal(stim.ndim, len(shape))
+#     npt.assert_equal(stim.size, np.prod(shape))
+#     # Zeros will be trimmed:
+#     stim = Stimulus(np.arange(4) - 2)
+#     npt.assert_equal(np.allclose(stim.coords['electrode'], [0, 1, 3]), True)
+#     npt.assert_equal(np.allclose(stim.data, [-2, -1, 1]), True)
+#     npt.assert_equal(len(stim), size - 1)
+
+#     # From list:
+#     stim = Stimulus([0, 0, 2] * size)
+#     npt.assert_equal(len(stim), size)
+
+#     # From tuple:
+#     stim = Stimulus((0, 2, 5, 2))
+#     npt.assert_equal(len(stim), 3)
+
+#     # With coordinates:

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -18,16 +18,16 @@ def test_Stimulus():
     npt.assert_equal(stim.electrodes, ['AA001'])
     npt.assert_equal(stim.time, None)
     # Ten electrodes, one will be trimmed:
-    stim = Stimulus(np.arange(10))
+    stim = Stimulus(np.arange(10), compress=True)
     npt.assert_equal(stim.shape, (9, 1))
     npt.assert_equal(stim.electrodes, np.arange(1, 10))
     npt.assert_equal(stim.time, None)
     # Electrodes + specific time, time will be trimmed:
-    stim = Stimulus(np.ones((4, 3)), time=[-3, -2, -1])
+    stim = Stimulus(np.ones((4, 3)), time=[-3, -2, -1], compress=True)
     npt.assert_equal(stim.shape, (4, 2))
     npt.assert_equal(stim.time, [-3, -1])
     # Electrodes + specific time, but don't trim:
-    stim = Stimulus(np.ones((4, 3)), time=[-3, -2, -1], sparsify=False)
+    stim = Stimulus(np.ones((4, 3)), time=[-3, -2, -1], compress=False)
     npt.assert_equal(stim.shape, (4, 3))
     npt.assert_equal(stim.time, [-3, -2, -1])
     # Specific names:
@@ -41,15 +41,26 @@ def test_Stimulus():
     npt.assert_equal(np.sort(stim.electrodes), np.sort(['B7', 'B8']))
     npt.assert_equal(stim.time, None)
     # Electrodes x time, time will be trimmed:
-    stim = Stimulus(np.ones((6, 100)))
+    stim = Stimulus(np.ones((6, 100)), compress=True)
     npt.assert_equal(stim.shape, (6, 2))
     # Single electrode in time:
-    stim = Stimulus(PulseTrain(0.01 / 1000, dur=0.005))
+    stim = Stimulus(PulseTrain(0.01 / 1000, dur=0.005), compress=False)
+    npt.assert_equal(stim.electrodes, [0])
+    npt.assert_equal(stim.shape, (1, 500))
+    stim = Stimulus(PulseTrain(0.01 / 1000, dur=0.005), compress=True)
+    npt.assert_equal(stim.electrodes, [0])
+    npt.assert_equal(stim.shape, (1, 8))
     # Specific electrode in time:
-    stim = Stimulus({'C3': PulseTrain(0.01 / 1000, dur=0.004)})
+    stim = Stimulus({'C3': PulseTrain(0.01 / 1000, dur=0.004)}, compress=False)
+    npt.assert_equal(stim.electrodes, ['C3'])
+    npt.assert_equal(stim.shape, (1, 400))
+    stim = Stimulus({'C3': PulseTrain(0.01 / 1000, dur=0.004)}, compress=True)
+    npt.assert_equal(stim.electrodes, ['C3'])
+    npt.assert_equal(stim.shape, (1, 8))
     # Multiple specific electrodes in time:
     stim = Stimulus({'C3': PulseTrain(0.01 / 1000, dur=0.004),
-                     'F4': PulseTrain(0.01 / 1000, delay=0.0001, dur=0.004)})
+                     'F4': PulseTrain(0.01 / 1000, delay=0.0001, dur=0.004)},
+                    compress=True)
     # Stimulus from a Stimulus (might happen in ProsthesisSystem):
     stim = Stimulus(Stimulus(4), electrodes='B3')
     npt.assert_equal(stim.shape, (1, 1))
@@ -60,33 +71,33 @@ def test_Stimulus():
     stim = Stimulus(3, metadata=metadata)
     npt.assert_equal(stim.metadata, metadata)
     # List of lists instead of 2D NumPy array:
-    stim = Stimulus([[1, 1, 1, 1, 1], [1, 1, 1, 1, 1]])
+    stim = Stimulus([[1, 1, 1, 1, 1], [1, 1, 1, 1, 1]], compress=True)
     npt.assert_equal(stim.shape, (2, 2))
     npt.assert_equal(stim.electrodes, [0, 1])
     npt.assert_equal(stim.time, [0, 4])
     # Tuple of tuples instead of 2D NumPy array:
-    stim = Stimulus(((1, 1, 1, 1, 1), (1, 1, 1, 1, 1)))
+    stim = Stimulus(((1, 1, 1, 1, 1), (1, 1, 1, 1, 1)), compress=True)
     npt.assert_equal(stim.shape, (2, 2))
     npt.assert_equal(stim.electrodes, [0, 1])
     npt.assert_equal(stim.time, [0, 4])
     # Zero activation:
     source = np.zeros((2, 4))
-    stim = Stimulus(source, sparsify=True)
+    stim = Stimulus(source, compress=True)
     npt.assert_equal(stim.shape, (0, 2))
     npt.assert_equal(stim.time, [0, source.shape[1] - 1])
-    stim = Stimulus(source, sparsify=False)
+    stim = Stimulus(source, compress=False)
     npt.assert_equal(stim.shape, source.shape)
     npt.assert_equal(stim.time, np.arange(source.shape[1]))
 
     # Rename electrodes:
-    stim = Stimulus(np.ones((2, 5)))
+    stim = Stimulus(np.ones((2, 5)), compress=True)
     npt.assert_equal(stim.electrodes, [0, 1])
     stim = Stimulus(stim, electrodes=['A3', 'B8'])
     npt.assert_equal(stim.electrodes, ['A3', 'B8'])
     npt.assert_equal(stim.time, [0, 4])
 
     # Specify new time points:
-    stim = Stimulus(np.ones((2, 5)))
+    stim = Stimulus(np.ones((2, 5)), compress=True)
     npt.assert_equal(stim.time, [0, 4])
     stim = Stimulus(stim, time=np.array(stim.time) / 10.0)
     npt.assert_equal(stim.electrodes, [0, 1])
@@ -118,28 +129,30 @@ def test_Stimulus():
 
 
 @pytest.mark.parametrize('tsample', (5e-6, 1e-7))
-def test_Stimulus_sparsify(tsample):
+def test_Stimulus_compress(tsample):
     # Single pulse train:
     pdur = 0.00045
     pt = PulseTrain(tsample, pulse_dur=pdur, dur=0.005)
     idata = pt.data.reshape((1, -1))
     ielec = np.array([0])
     itime = np.arange(idata.shape[-1]) * pt.tsample
-    # Sparsify should compress the data. The original `tsample` shouldn't
-    # matter as long as the resolution is fine enough to capture all of the
-    # pulse train:
-    odata, oelec, otime = Stimulus.sparsify(idata, ielec, itime)
-    npt.assert_equal(odata.shape, (1, 8))
+    stim = Stimulus(idata, electrodes=ielec, time=itime, compress=False)
+    npt.assert_equal(stim.compressed, False)
+    # Compress the data. The original `tsample` shouldn't matter as long as the
+    # resolution is fine enough to capture all of the pulse train:
+    stim.compress()
+    npt.assert_equal(stim.compressed, True)
+    npt.assert_equal(stim.shape, (1, 8))
     # Electrodes are unchanged:
-    npt.assert_equal(ielec, oelec)
+    npt.assert_equal(ielec, stim.electrodes)
     # First and last time step are always preserved:
-    npt.assert_almost_equal(itime[0], otime[0])
-    npt.assert_almost_equal(itime[-1], otime[-1])
+    npt.assert_almost_equal(itime[0], stim.time[0])
+    npt.assert_almost_equal(itime[-1], stim.time[-1])
     # The first rising edge happens at t=`pdur`:
-    npt.assert_almost_equal(otime[1], pdur - tsample)
-    npt.assert_almost_equal(odata[0, 1], -20)
-    npt.assert_almost_equal(otime[2], pdur)
-    npt.assert_almost_equal(odata[0, 2], 0)
+    npt.assert_almost_equal(stim.time[1], pdur - tsample)
+    npt.assert_almost_equal(stim.data[0, 1], -20)
+    npt.assert_almost_equal(stim.time[2], pdur)
+    npt.assert_almost_equal(stim.data[0, 2], 0)
 
     # Two pulse trains with slight delay/offset, and a third that's all 0:
     delay = 0.0001
@@ -149,29 +162,78 @@ def test_Stimulus_sparsify(tsample):
     idata = np.vstack((pt.data, pt2.data, pt3.data))
     ielec = np.array([0, 1, 2])
     itime = np.arange(idata.shape[-1]) * pt.tsample
-    # Sparsify should compress the data. The original `tsample` shouldn't
-    # matter as long as the resolution is fine enough to capture all of the
-    # pulse train:
-    odata, oelec, otime = Stimulus.sparsify(idata, ielec, itime)
-    npt.assert_equal(odata.shape, (2, 16))
+    stim = Stimulus(idata, electrodes=ielec, time=itime, compress=False)
+    npt.assert_equal(stim.compressed, False)
+    # Compress the data:
+    stim.compress()
+    npt.assert_equal(stim.compressed, True)
+    npt.assert_equal(stim.shape, (2, 16))
     # Zero electrodes should be deselected:
-    npt.assert_equal(oelec, np.array([0, 1]))
+    npt.assert_equal(stim.electrodes, np.array([0, 1]))
     # First and last time step are always preserved:
-    npt.assert_almost_equal(itime[0], otime[0])
-    npt.assert_almost_equal(itime[-1], otime[-1])
+    npt.assert_almost_equal(itime[0], stim.time[0])
+    npt.assert_almost_equal(itime[-1], stim.time[-1])
     # The first rising edge happens at t=`delay`:
-    npt.assert_almost_equal(otime[1], delay - tsample)
-    npt.assert_almost_equal(odata[0, 1], -20)
-    npt.assert_almost_equal(odata[1, 1], 0)
-    npt.assert_almost_equal(otime[2], delay)
-    npt.assert_almost_equal(odata[0, 2], -20)
-    npt.assert_almost_equal(odata[1, 2], -20)
+    npt.assert_almost_equal(stim.time[1], delay - tsample)
+    npt.assert_almost_equal(stim.data[0, 1], -20)
+    npt.assert_almost_equal(stim.data[1, 1], 0)
+    npt.assert_almost_equal(stim.time[2], delay)
+    npt.assert_almost_equal(stim.data[0, 2], -20)
+    npt.assert_almost_equal(stim.data[1, 2], -20)
 
-    # Repeated calls to sparsify won't change the result:
-    idata = odata
-    ielec = oelec
-    itime = otime
-    odata, oelec, otime = Stimulus.sparsify(idata, ielec, itime)
-    npt.assert_equal(idata, odata)
-    npt.assert_equal(ielec, oelec)
-    npt.assert_equal(itime, otime)
+    # Repeated calls to compress won't change the result:
+    idata = stim.data
+    ielec = stim.electrodes
+    itime = stim.time
+    stim.compress()
+    npt.assert_equal(stim.compressed, True)
+    npt.assert_equal(idata, stim.data)
+    npt.assert_equal(ielec, stim.electrodes)
+    npt.assert_equal(itime, stim.time)
+
+
+@pytest.mark.parametrize('time', [0, 0.9, 12.5, np.array([3.5, 7.8])])
+@pytest.mark.parametrize('shape', [(1, 4), (2, 2), (3, 5)])
+def test_Stimulus_interp(time, shape):
+    # Time is None: nothing to interpolate/extrapolate, simply return the
+    # original data
+    stim = Stimulus(np.ones(shape[0]))
+    npt.assert_almost_equal(stim.interp(time=None).data, stim.data)
+
+    # Single time point: nothing to interpolate/extrapolate, simply return the
+    # original data
+    data = np.ones(shape).reshape((-1, 1))
+    stim = Stimulus(data)
+    npt.assert_almost_equal(stim.interp(time=time).data, data)
+
+    # Specific time steps:
+    stim = Stimulus([np.arange(shape[1])] * shape[0], compress=False)
+    npt.assert_almost_equal(stim.interp(time=time).data,
+                            np.ones((shape[0], 1)) * time)
+    npt.assert_almost_equal(stim.interp(time=[time]).data,
+                            np.ones((shape[0], 1)) * time)
+    # All time steps:
+    npt.assert_almost_equal(stim.interp(time=stim.time).data, stim.data)
+
+
+def test_Stimulus___eq__():
+    # Two Stimulus objects created from the same source data are considered
+    # equal:
+    for source in [3, [], np.ones(3), [3, 4, 5], np.ones((3, 6))]:
+        npt.assert_equal(Stimulus(source) == Stimulus(source), True)
+    stim = Stimulus(np.ones((2, 3)), compress=True)
+    # Compressed vs uncompressed:
+    npt.assert_equal(stim == Stimulus(np.ones((2, 3)), compress=False), False)
+    npt.assert_equal(stim != Stimulus(np.ones((2, 3)), compress=False), True)
+    # Different electrode names:
+    npt.assert_equal(stim == Stimulus(stim, electrodes=[0, 'A2']), False)
+    # Different time points:
+    npt.assert_equal(stim == Stimulus(stim, time=[0, 3], compress=True), False)
+    # Different data shape:
+    npt.assert_equal(stim == Stimulus(np.ones((2, 4))), False)
+    npt.assert_equal(stim == Stimulus(np.ones(2)), False)
+    # Different data points:
+    npt.assert_equal(stim == Stimulus(np.ones((2, 3)) * 1.1), False)
+    # Different type:
+    npt.assert_equal(stim == np.ones((2, 3)), False)
+    npt.assert_equal(stim != np.ones((2, 3)), True)

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -59,7 +59,16 @@ def test_Stimulus():
     metadata = {'a': 0, 'b': 1}
     stim = Stimulus(3, metadata=metadata)
     npt.assert_equal(stim.metadata, metadata)
-
+    # List of lists instead of 2D NumPy array:
+    stim = Stimulus([[1, 1, 1, 1, 1], [1, 1, 1, 1, 1]])
+    npt.assert_equal(stim.shape, (2, 2))
+    npt.assert_equal(stim.electrodes, [0, 1])
+    npt.assert_equal(stim.time, [0, 4])
+    # Tuple of tuples instead of 2D NumPy array:
+    stim = Stimulus(((1, 1, 1, 1, 1), (1, 1, 1, 1, 1)))
+    npt.assert_equal(stim.shape, (2, 2))
+    npt.assert_equal(stim.electrodes, [0, 1])
+    npt.assert_equal(stim.time, [0, 4])
     # Zero activation:
     source = np.zeros((2, 4))
     stim = Stimulus(source, sparsify=True)
@@ -68,6 +77,20 @@ def test_Stimulus():
     stim = Stimulus(source, sparsify=False)
     npt.assert_equal(stim.shape, source.shape)
     npt.assert_equal(stim.time, np.arange(source.shape[1]))
+
+    # Rename electrodes:
+    stim = Stimulus(np.ones((2, 5)))
+    npt.assert_equal(stim.electrodes, [0, 1])
+    stim = Stimulus(stim, electrodes=['A3', 'B8'])
+    npt.assert_equal(stim.electrodes, ['A3', 'B8'])
+    npt.assert_equal(stim.time, [0, 4])
+
+    # Specify new time points:
+    stim = Stimulus(np.ones((2, 5)))
+    npt.assert_equal(stim.time, [0, 4])
+    stim = Stimulus(stim, time=np.array(stim.time) / 10.0)
+    npt.assert_equal(stim.electrodes, [0, 1])
+    npt.assert_equal(stim.time, [0, 0.4])
 
     # Not allowed:
     with pytest.raises(ValueError):
@@ -152,26 +175,3 @@ def test_Stimulus_sparsify(tsample):
     npt.assert_equal(idata, odata)
     npt.assert_equal(ielec, oelec)
     npt.assert_equal(itime, otime)
-
-
-# def test_Stimulus__from_ndarray():
-#     # From NumPy array:
-#     shape = (2, 4)
-#     stim = Stimulus(np.ones(shape))
-#     npt.assert_equal(stim.ndim, len(shape))
-#     npt.assert_equal(stim.size, np.prod(shape))
-#     # Zeros will be trimmed:
-#     stim = Stimulus(np.arange(4) - 2)
-#     npt.assert_equal(np.allclose(stim.coords['electrode'], [0, 1, 3]), True)
-#     npt.assert_equal(np.allclose(stim.data, [-2, -1, 1]), True)
-#     npt.assert_equal(len(stim), size - 1)
-
-#     # From list:
-#     stim = Stimulus([0, 0, 2] * size)
-#     npt.assert_equal(len(stim), size)
-
-#     # From tuple:
-#     stim = Stimulus((0, 2, 5, 2))
-#     npt.assert_equal(len(stim), 3)
-
-#     # With coordinates:

--- a/pulse2percept/utils/base.py
+++ b/pulse2percept/utils/base.py
@@ -43,8 +43,10 @@ class PrettyPrint(object, metaclass=abc.ABCMeta):
 
     def __repr__(self):
         """Pretty print class as: ClassName(arg1=val1, arg2=val2)"""
+        # Shorten NumPy array output:
+        np.set_printoptions(precision=2, threshold=5, edgeitems=2)
         # Line width:
-        lwidth = 70
+        lwidth = 80
         # Sort list of parameters alphabetically:
         sorted_params = coll.OrderedDict(sorted(self.get_params().items()))
         # Start string with class name, followed by all arguments:
@@ -59,11 +61,18 @@ class PrettyPrint(object, metaclass=abc.ABCMeta):
                 # Need extra '' around strings for repr:
                 sparam = key + '=\'' + str(val) + '\', '
             else:
-                strobj = str(val)
-                if len(strobj) > lwidth - lindent:
-                    # Too long, just show the type:
-                    strobj = str(type(val)).replace("<class '", "")
-                    strobj = strobj.replace("'>", "")
+                if isinstance(val, np.ndarray):
+                    # Print NumPy arrays without line breaks:
+                    strobj = np.array2string(val).replace('\n', ',')
+                    # If still too long, show shape:
+                    if len(strobj) > lwidth - lindent:
+                        strobj = '<%s np.ndarray>' % str(val.shape)
+                else:
+                    strobj = str(val)
+                    if len(strobj) > lwidth - lindent:
+                        # Too long, just show the type:
+                        strobj = str(type(val)).replace("<class '", "")
+                        strobj = strobj.replace("'>", "")
                 sparam = key + '=' + strobj + ', '
             # If adding `sparam` puts line over `lwidth`, start a new line:
             if lc + len(sparam) > lwidth:

--- a/pulse2percept/utils/tests/test_convolution.py
+++ b/pulse2percept/utils/tests/test_convolution.py
@@ -8,6 +8,7 @@ from unittest import mock
 from imp import reload
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize('mode', ('full', 'valid', 'same'))
 @pytest.mark.parametrize('method', ('sparse', 'fft'))
 @pytest.mark.parametrize('use_jit', (True, False))

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ NUMPY_MIN_VERSION = '1.9.0'
 SCIPY_MIN_VERSION = '1.0'
 CYTHON_MIN_VERSION = '0.28'
 JOBLIB_MIN_VERSION = '0.11'
-XARRAY_MIN_VERSION = '0.12'
 
 DISTNAME = 'pulse2percept'
 DESCRIPTION = 'A Python-based simulation framework for bionic vision'
@@ -158,25 +157,6 @@ def get_cython_status():
     return cython_status
 
 
-def get_xarray_status():
-    """
-    Returns a dictionary containing a boolean specifying whether xarray is
-    up-to-date, along with the version string (empty string if not installed).
-    """
-    status = {}
-    try:
-        import xarray as xr
-        version = xr.__version__
-        status['up_to_date'] = parse_version(
-            version) >= parse_version(XARRAY_MIN_VERSION)
-        status['version'] = version
-    except ImportError:
-        traceback.print_exc()
-        status['up_to_date'] = False
-        status['version'] = ""
-    return status
-
-
 def setup_package():
     metadata = dict(name=DISTNAME,
                     maintainer=MAINTAINER,
@@ -213,8 +193,7 @@ def setup_package():
                     install_requires=[
                         'numpy>={}'.format(NUMPY_MIN_VERSION),
                         'scipy>={}'.format(SCIPY_MIN_VERSION),
-                        'joblib>={}'.format(JOBLIB_MIN_VERSION),
-                        'xarray>={}'.format(XARRAY_MIN_VERSION)
+                        'joblib>={}'.format(JOBLIB_MIN_VERSION)
                     ],
                     **extra_setuptools_args)
 
@@ -277,20 +256,6 @@ def setup_package():
                 raise ImportError("C-Extensions for Python (Cython) is not "
                                   "installed.\n{}{}"
                                   .format(cython_req_str, instructions))
-
-        xr_status = get_xarray_status()
-        xr_req_str = "pulse2percept requires Xarray >= {}.\n".format(
-            XARRAY_MIN_VERSION
-        )
-        if cython_status['up_to_date'] is False:
-            if cython_status['version']:
-                raise ImportError("Your installation of Xarray {} is "
-                                  "out-of-date.\n{}{}"
-                                  .format(xr_status['version'], xr_req_str,
-                                          instructions))
-            else:
-                raise ImportError("Xarray not installed.\n{}{}".format(
-                    xarray_req_str, instructions))
 
         metadata['configuration'] = configuration
 


### PR DESCRIPTION
- [X] defines a common interface for all stimuli
- [X] can handle stimuli with and without a time component
- [X] creates stimuli from various source types (e.g., scalars, NumPy arrays, `TimeSeries`, lists, dicts)
- [X] efficiently stores `TimeSeries` data (dropping redundant items)
- [X] removes `xarray` dependency
- [X] automatically fixes issue with inconsistent tsamples (issue #90)

In the future, this might replace `TimeSeries`.