### PR TITLE
[REF] Refactor Stimulus object

### DIFF
--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -126,7 +126,7 @@ class Stimulus(PrettyPrint):
 
     >>> from pulse2percept.stimuli import Stimulus
     >>> stim = Stimulus(np.arange(10).reshape((1, -1)))
-    >>> stim.interp(time=3.45) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> stim[:, 3.45]) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     Stimulus(data=[[...3.45]], electrodes=[0], interp_method='linear',
              shape=(1, 1), time=[...3.45])
 

--- a/pulse2percept/stimuli/base.py
+++ b/pulse2percept/stimuli/base.py
@@ -517,7 +517,7 @@ class Stimulus(PrettyPrint):
 
     @property
     def data(self):
-        """Data container
+        """Stimulus data container
 
         A 2-D NumPy array that contains the stimulus data, where the rows
         denote electrodes and the columns denote points in time.
@@ -526,20 +526,39 @@ class Stimulus(PrettyPrint):
 
     @property
     def shape(self):
+        """Data container shape"""
         return self.data.shape
 
     @property
     def electrodes(self):
+        """Electrode names
+
+        A list of electrode names, corresponding to the rows in the data
+        container.
+        """
         return self._stim['electrodes']
 
     @property
     def time(self):
+        """Time steps
+
+        A list of time steps, corresponding to the columns in the data
+        container.
+        """
         return self._stim['time']
 
     @property
     def metadata(self):
+        """Metadata
+
+        A dictionary of metadata about the stimulus.
+        """
         return self._stim['metadata']
 
     @property
     def interp_method(self):
+        """Interpolation method
+
+        The method used to interpolate stimulus values at specific time steps.
+        """
         return self._stim['interp_method']

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -295,3 +295,27 @@ def test_Stimulus___eq__():
     # Different type:
     npt.assert_equal(stim == np.ones((2, 3)), False)
     npt.assert_equal(stim != np.ones((2, 3)), True)
+
+
+def test_Stimulus___getitem__():
+    stim = Stimulus(np.arange(12).reshape((3, 4)))
+    # Slicing:
+    npt.assert_equal(stim[:], stim.data)
+    npt.assert_equal(stim[...], stim.data)
+    npt.assert_equal(stim[:, :], stim.data)
+    npt.assert_equal(stim[:2], stim.data[:2])
+    npt.assert_equal(stim[:, 0], stim.data[:, 0])
+    npt.assert_equal(stim[0, :], stim.data[0, :])
+    npt.assert_equal(stim[0, ...], stim.data[0, ...])
+    npt.assert_equal(stim[..., 0], stim.data[..., 0])
+    # Single element:
+    npt.assert_equal(stim[0, 0], stim.data[0, 0])
+    # Interpolating time:
+    npt.assert_almost_equal(stim[0, 3.3], 3.3)
+    npt.assert_almost_equal(stim[..., 3.3], np.array([[3.3], [7.3], [11.3]]))
+    # Extrapolating should be disabled by default:
+    npt.assert_almost_equal(stim[0, 9.9], 9.9)
+    with pytest.raises(IndexError):
+        stim[10, :]
+    with pytest.raises(TypeError):
+        stim[3.3, 0]

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -137,11 +137,9 @@ def test_Stimulus_compress(tsample):
     ielec = np.array([0])
     itime = np.arange(idata.shape[-1]) * pt.tsample
     stim = Stimulus(idata, electrodes=ielec, time=itime, compress=False)
-    npt.assert_equal(stim.compressed, False)
     # Compress the data. The original `tsample` shouldn't matter as long as the
     # resolution is fine enough to capture all of the pulse train:
     stim.compress()
-    npt.assert_equal(stim.compressed, True)
     npt.assert_equal(stim.shape, (1, 8))
     # Electrodes are unchanged:
     npt.assert_equal(ielec, stim.electrodes)
@@ -163,10 +161,8 @@ def test_Stimulus_compress(tsample):
     ielec = np.array([0, 1, 2])
     itime = np.arange(idata.shape[-1]) * pt.tsample
     stim = Stimulus(idata, electrodes=ielec, time=itime, compress=False)
-    npt.assert_equal(stim.compressed, False)
     # Compress the data:
     stim.compress()
-    npt.assert_equal(stim.compressed, True)
     npt.assert_equal(stim.shape, (2, 16))
     # Zero electrodes should be deselected:
     npt.assert_equal(stim.electrodes, np.array([0, 1]))
@@ -186,7 +182,6 @@ def test_Stimulus_compress(tsample):
     ielec = stim.electrodes
     itime = stim.time
     stim.compress()
-    npt.assert_equal(stim.compressed, True)
     npt.assert_equal(idata, stim.data)
     npt.assert_equal(ielec, stim.electrodes)
     npt.assert_equal(itime, stim.time)

--- a/pulse2percept/stimuli/tests/test_base.py
+++ b/pulse2percept/stimuli/tests/test_base.py
@@ -89,6 +89,12 @@ def test_Stimulus():
     stim = Stimulus(source, compress=False)
     npt.assert_equal(stim.shape, source.shape)
     npt.assert_equal(stim.time, np.arange(source.shape[1]))
+    # Annoying but possible:
+    stim = Stimulus([])
+    npt.assert_equal(stim.time, None)
+    npt.assert_equal(len(stim.data), 0)
+    npt.assert_equal(len(stim.electrodes), 0)
+    npt.assert_equal(stim.shape, (0,))
 
     # Rename electrodes:
     stim = Stimulus(np.ones((2, 5)), compress=True)
@@ -240,30 +246,6 @@ def test_Stimulus__stim():
     stim._stim = data
 
 
-# @pytest.mark.parametrize('time', [0, 0.9, 12.5, np.array([3.5, 7.8])])
-# @pytest.mark.parametrize('shape', [(1, 4), (2, 2), (3, 5)])
-# def test_Stimulus_interp(time, shape):
-#     # Time is None: nothing to interpolate/extrapolate, simply return the
-#     # original data
-#     stim = Stimulus(np.ones(shape[0]))
-#     npt.assert_almost_equal(stim.interp(time=None).data, stim.data)
-
-#     # Single time point: nothing to interpolate/extrapolate, simply return the
-#     # original data
-#     data = np.ones(shape).reshape((-1, 1))
-#     stim = Stimulus(data)
-#     npt.assert_almost_equal(stim.interp(time=time).data, data)
-
-#     # Specific time steps:
-#     stim = Stimulus([np.arange(shape[1])] * shape[0], compress=False)
-#     npt.assert_almost_equal(stim.interp(time=time).data,
-#                             np.ones((shape[0], 1)) * time)
-#     npt.assert_almost_equal(stim.interp(time=[time]).data,
-#                             np.ones((shape[0], 1)) * time)
-#     # All time steps:
-#     npt.assert_almost_equal(stim.interp(time=stim.time).data, stim.data)
-
-
 def test_Stimulus___eq__():
     # Two Stimulus objects created from the same source data are considered
     # equal:
@@ -285,6 +267,8 @@ def test_Stimulus___eq__():
     # Different type:
     npt.assert_equal(stim == np.ones((2, 3)), False)
     npt.assert_equal(stim != np.ones((2, 3)), True)
+    # Annoying but possible:
+    npt.assert_equal(Stimulus([]), Stimulus(()))
 
 
 def test_Stimulus___getitem__():
@@ -327,3 +311,8 @@ def test_Stimulus___getitem__():
         stim[0, 3.33]
     stim = Stimulus(np.arange(3).reshape((-1, 1)), extrapolate=True)
     npt.assert_almost_equal(stim[0, 3.33], stim.data[0, 0])
+    # Annoying but possible:
+    stim = Stimulus([])
+    npt.assert_almost_equal(stim[:], stim.data)
+    with pytest.raises(IndexError):
+        stim[0]


### PR DESCRIPTION
- [X] Store data internally as `_stim` dict, so that consistency between `data` container and its labeled axes `electrodes` and `time` can be ensured
- [X] Turn `data`, `electrodes`, `time`, and `shape` into properties
- [X] Replace `interp` method with smart `__getitem__` that can in interpolate time (closes #121)